### PR TITLE
tui: hide gagged items in history splitview

### DIFF
--- a/mudpuppy/src/tui/splitview.rs
+++ b/mudpuppy/src/tui/splitview.rs
@@ -105,6 +105,10 @@ impl ScrollWindow {
 
 fn filter_item(item: &output::Item, echo_input: bool) -> bool {
     match item {
+        // Hide gagged MUD items
+        // TODO(XXX): Offer a way to disable gagging for troubleshooting?
+        output::Item::Mud { line } if line.gag => false,
+
         // Hide input items when echo_input is disabled. The user doesn't want to see their own
         // input displayed in the output buff.
         output::Item::Input { .. } if !echo_input => false,


### PR DESCRIPTION
The `mudbuffer.rs` TUI code was filtering gagged MUD items but the splitview was not. In the future we can consider (for both, or separately) exposing a config to display gagged items (perhaps grayed out) as a debug aide.