### PR TITLE
support triggers on prompt lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,16 @@ find the text of the prompt and the `SessionId` of the MUD.
         logging.debug(f"prompt event: {event}")
     ```
 
+You can also create triggers that only match on prompts by setting
+`prompt=True`. This can be used to conditionally gag prompts:
+
+    ```python
+
+    @trigger(name="Gag login prompts", prompt=True, gag=True, pattern=r"(?:Enter your username: )|(?:Password: )")
+    async def gag_prompts(_session_id: SessionId, _trigger_id: TriggerId, line: str, _groups: Any):
+        logging.debug(f"\nI just gagged this prompt:\n{line}\n")
+    ```
+
 #### Creating a Timer
 
 Timers allow you to execute actions periodically, either globally or for

--- a/mudpuppy/python/cmd_trigger.py
+++ b/mudpuppy/python/cmd_trigger.py
@@ -51,6 +51,11 @@ class TriggerCmd(Command):
             action="store_true",
         )
         add_parser.add_argument(
+            "--prompt",
+            help="Only match prompt lines",
+            action="store_true",
+        )
+        add_parser.add_argument(
             "--ansi",
             help="Match trigger with ANSI colour preserved",
             action="store_true",
@@ -102,9 +107,13 @@ class TriggerCmd(Command):
         if args.pattern is None:
             return
         new_trigger = TriggerConfig(args.pattern, args.name)
-        new_trigger.expansion = " ".join(args.command)
+        expansion = " ".join(args.command).strip()
+        if expansion != "":
+            new_trigger.expansion = expansion
         if args.gag:
             new_trigger.gag = True
+        if args.prompt:
+            new_trigger.prompt = True
         if not args.ansi:
             new_trigger.strip_ansi = True
         trig_id = await mudpuppy_core.new_trigger(sesh_id, new_trigger, __name__)
@@ -150,7 +159,7 @@ class TriggerCmd(Command):
 
             output_items.append(
                 OutputItem.command_result(
-                    f"{trigger.id}: Hits={trigger.config.hit_count} Gag={trigger.config.gag} Pattern={repr(trigger.config.pattern())} {label}",
+                    f"{trigger.id}: Hits={trigger.config.hit_count} Gag={trigger.config.gag} Prompt={trigger.config.prompt} Pattern={repr(trigger.config.pattern())} {label}",
                 )
             )
         await mudpuppy_core.add_outputs(sesh_id, output_items)

--- a/mudpuppy/python/mudpuppy.py
+++ b/mudpuppy/python/mudpuppy.py
@@ -267,6 +267,7 @@ def trigger(
     name: str,
     gag: bool = False,
     strip_ansi: bool = True,
+    prompt: bool = False,
     expansion: Optional[str] = None,
     mud_name: Optional[str] = None,
     module: Optional[str] = None,
@@ -279,6 +280,7 @@ def trigger(
 
         trigger_config = TriggerConfig(pattern, name)
         trigger_config.gag = gag
+        trigger_config.prompt = prompt
         trigger_config.strip_ansi = strip_ansi
         trigger_config.expansion = expansion
         trigger_config.callback = handler

--- a/mudpuppy/src/model.rs
+++ b/mudpuppy/src/model.rs
@@ -397,6 +397,9 @@ pub struct TriggerConfig {
     pub strip_ansi: bool,
 
     #[pyo3(get, set)]
+    pub prompt: bool,
+
+    #[pyo3(get, set)]
     pub gag: bool,
 
     #[pyo3(get, set)]
@@ -423,6 +426,9 @@ impl TriggerConfig {
     // TODO(XXX): Tidy, remove unwrap.
     #[must_use]
     pub fn matches(&self, line: &MudLine) -> (bool, Option<Vec<String>>) {
+        if !line.prompt && self.prompt {
+            return (false, None);
+        }
         // TODO(XXX): Cleanup with MSRV 1.81 lifetime coolness
         let stripped_haystack;
         let haystack;
@@ -457,6 +463,7 @@ impl TriggerConfig {
         Ok(Self {
             name,
             strip_ansi: false,
+            prompt: false,
             gag: false,
             callback: None,
             highlight: None,

--- a/mudpuppy/src/tui/mudbuffer.rs
+++ b/mudpuppy/src/tui/mudbuffer.rs
@@ -97,6 +97,9 @@ impl MudBuffer {
                     // Hide prompt items when hold_prompt is true. The held prompt will supersede
                     // historic prompts.
                     output::Item::Prompt { .. } if self.mud.hold_prompt => false,
+                    // Hide gagged prompts.
+                    output::Item::Prompt { prompt } if prompt.gag => false,
+                    output::Item::HeldPrompt { prompt } if prompt.gag => false,
                     _ => true,
                 }
             },

--- a/mudpuppy/src/tui/splitview.rs
+++ b/mudpuppy/src/tui/splitview.rs
@@ -116,6 +116,9 @@ fn filter_item(item: &output::Item, echo_input: bool) -> bool {
         // When viewing history we want to see the normal prompt items, but not the held prompt.
         output::Item::HeldPrompt { .. } => false,
 
+        // Hide gagged prompts.
+        output::Item::Prompt { prompt } if prompt.gag => false,
+
         // Show everything else.
         _ => true,
     }


### PR DESCRIPTION
It's now possible to indicate in a trigger config if the pattern should only match lines detected as a prompt. Writing this kind of trigger is an alternative to writing prompt event handlers and allows for gagging the prompt lines and more complex pattern matching.

For a decorator trigger that only matches on prompt lines, add `prompt=True`, e.g:

```python
@trigger(name="Gag login prompts", prompt=True, gag=True, pattern=r"(?:Enter your username: )|(?:Password: )")
async def gag_prompts(_session_id: SessionId, _trigger_id: TriggerId, line: str, _groups: Any):
  logging.debug(f"\nI just gagged this prompt:\n{line}\n")
```

For a trigger added in-client that only matches on prompt lines, add `--prompt`, e.g:

```
/trigger add --name='Gag username prompt' --prompt --gag --pattern='Enter your username: '
```

Mechanically this diff:

* Tracks the setting in the trigger config model.
* Updates partial line events to run the prompt mudline through the trigger machinery before further processing.
* Updates the places that display prompts, or held prompts, to respect the gag setting on the mudline.
* Wires through the relevant new bits of config in the Python trigger decorator and the `/trigger` command.
* Fixes a bug in `/trigger add` that created empty expansion lines for triggers added without an expansion command.

Resolves https://github.com/mudpuppy-rs/mudpuppy/issues/11