### PR TITLE
support multiple `mud_name`s in decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,17 @@ MUD or all MUDs.
 The line that matched the alias, as well as any regexp groups in the pattern are
 provided to the alias callback function alongside the `SessionId` of the MUD.
 
-- **Target a specific MUD**: Use `mud_name` to create an alias for a specific MUD:
+- **Target a specific MUD, or list of MUDs**: Use `mud_name` to create an alias
+  for a specific MUD, or list of MUDs:
     ```python
     @alias(mud_name="Dune (TLS)", pattern="^test$", name="Test Alias")
     async def test(session_id: SessionId, _alias_id: AliasId, _line: str, _groups):
         # Send a command when the alias is run
         mudpuppy_core.send(session_id, "say this is an alias test!")
+
+    @alias(mud_name=["Dune (TLS)", "Threshold"], pattern="^eepy$", name="Eepy")
+    async def eepy(session_id: SessionId, _alias_id: AliasId, _line: str, _groups):
+        mudpuppy_core.send(session_id, "say I'm eepy!")
     ```
 
 - **Simple commands**: Use 'expansion` to simplify the above example:

--- a/mudpuppy/python/mudpuppy.py
+++ b/mudpuppy/python/mudpuppy.py
@@ -124,7 +124,9 @@ def on_disconnected(module=None):
 
 
 def on_mud_event(
-    mud_name: str, event_type: Union[EventType, List[EventType]], module=None
+    mud_name: Union[str, List[str]],
+    event_type: Union[EventType, List[EventType]],
+    module=None,
 ):
     def on_mud_event_decorator(handler: EventHandler):
         ensure_async(handler)
@@ -135,15 +137,19 @@ def on_mud_event(
             if sesh_id is None:
                 return  # Global event - skip
             session_info_data = await mudpuppy_core.session_info(sesh_id)
-            if session_info_data.mud_name == mud_name:
-                await handler(event)
+            if isinstance(mud_name, str):
+                if session_info_data.mud_name == mud_name:
+                    await handler(event)
+            elif isinstance(mud_name, list):
+                if session_info_data.mud_name in mud_name:
+                    await handler(event)
 
         return on_mud_event_wrapper
 
     return on_mud_event_decorator
 
 
-def on_mud_new_session(mud_name: str, module=None):
+def on_mud_new_session(mud_name: Union[str, List[str]], module=None):
     def on_mud_new_session_decorator(handler: EventHandler):
         ensure_async(handler)
 
@@ -158,7 +164,7 @@ def on_mud_new_session(mud_name: str, module=None):
     return on_mud_new_session_decorator
 
 
-def on_mud_new_session_or_reload(mud_name: str, module=None):
+def on_mud_new_session_or_reload(mud_name: Union[str, List[str]], module=None):
     def on_mud_new_session_or_reload_decorator(handler: EventHandler):
         ensure_async(handler)
 
@@ -175,7 +181,7 @@ def on_mud_new_session_or_reload(mud_name: str, module=None):
     return on_mud_new_session_or_reload_decorator
 
 
-def on_mud_connected(mud_name: str, module=None):
+def on_mud_connected(mud_name: Union[str, List[str]], module=None):
     def on_mud_connected_decorator(handler: EventHandler):
         ensure_async(handler)
 
@@ -191,7 +197,7 @@ def on_mud_connected(mud_name: str, module=None):
     return on_mud_connected_decorator
 
 
-def on_mud_disconnected(mud_name: str, module=None):
+def on_mud_disconnected(mud_name: Union[str, List[str]], module=None):
     def on_mud_disconnected_decorator(handler: EventHandler):
         ensure_async(handler)
 
@@ -215,7 +221,7 @@ def alias(
     pattern: str,
     name: str,
     expansion: Optional[str] = None,
-    mud_name: Optional[str] = None,
+    mud_name: Optional[Union[str, List[str]]] = None,
     module: Optional[str] = None,
 ):
     def alias_decorator(handler: Callable):

--- a/python-examples/user_test.py
+++ b/python-examples/user_test.py
@@ -59,6 +59,18 @@ async def prompt_handler(event: Event):
     logging.debug(f"got prompt event: {event}")
 
 
+@trigger(
+    mud_name=["Test (TLS)", "Test (Telnet)"],
+    name="MultiMud",
+    pattern="^You say: secret.",
+    expansion="say sauce.",
+)
+async def multi_mud_test(
+    _session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups
+):
+    pass
+
+
 @on_mud_event("Test (TLS)", EventType.Prompt)
 async def test_prompt_handler(event: Event):
     logging.debug(f'test prompt is: "{str(event.prompt)}"')


### PR DESCRIPTION
It's now possible to specify a list for the `mud_name` argument of the various decorators (`@trigger`, `@alias`, `@on_event`, etc).

The registered handler will be activated for any MUD that matches one of the provided `mud_name`s.

E.g. an alias that's defined for two MUDs:

```python
@alias(mud_name=["Dune (TLS)", "Threshold"], pattern="^eepy$", name="Eepy", expansion="say I'm eepy")
async def eepy(session_id: SessionId, _alias_id: AliasId, _line: str, _groups):
  pass
```

Resolves https://github.com/mudpuppy-rs/mudpuppy/issues/24