### PR TITLE
docs: migrate content from README -> book

### DIFF
--- a/user-guide/src/SUMMARY.md
+++ b/user-guide/src/SUMMARY.md
@@ -1,3 +1,17 @@
 # Summary
 
-- [Introduction](./introduction.md)
+[Introduction](./introduction.md)
+
+# User Guide
+
+- [Command line](cli.md)
+- [Config](config.md)
+- [Commands](commands.md)
+- [Logging](logging.md)
+- [Scripting](scripting/README.md)
+    - [Aliases](scripting/aliases.md)
+    - [Triggers](scripting/triggers.md)
+    - [Timers](scripting/timers.md)
+    - [Custom Commands](scripting/custom_commands.md)
+    - [Output](scripting/output.md)
+    - [Prompts](scripting/prompts.md)

--- a/user-guide/src/chapter_1.md
+++ b/user-guide/src/chapter_1.md
@@ -1,1 +1,0 @@
-# Introduction

--- a/user-guide/src/cli.md
+++ b/user-guide/src/cli.md
@@ -1,0 +1,16 @@
+# Command line
+
+```
+A terminal MUD client, scripted with Python
+
+Usage: mudpuppy [OPTIONS]
+
+Options:
+  -f, --frame-rate <FLOAT>  Frame rate, i.e. number of frames per second [default: 60]
+  -c, --connect <MUD_NAME>  MUD name to auto-connect to at startup. Can be specified multiple times
+  -l, --log-level <LEVEL>   Log level filter. Default is INFO [default: INFO]
+  -h, --help                Print help
+  -V, --version             Print version
+```
+
+**TODO: Write CLI arg docs**

--- a/user-guide/src/commands.md
+++ b/user-guide/src/commands.md
@@ -1,0 +1,44 @@
+# Commands
+
+Mudpuppy has several built-in commands you can run from within the client. By
+default the command prefix is "/". The choice of prefix can be changed in your
+config file.
+
+## `/status`
+
+Shows the current connection status. Use `/status --verbose` for more
+information.
+
+## `/connect`
+
+Connects the current session if it isn't already connected.
+
+## `/disconnect`
+
+Disconnects the current session if it isn't already disconnected.
+
+## `/quit`
+
+Exits Mudpuppy.
+
+## `/reload`
+
+Reloads user python scripts. Scripts can define a handler to be called before
+reloading occurs if any clean-up needs to be done:
+
+```python
+# Called before /reload completes and the module is re-imported.
+def __reload__():
+    pass
+```
+
+## `/alias`, `/trigger`, `/timer`
+
+These commands allow creating simple aliases/triggers/timers that last only for
+the duration of the session. To create durable versions pref Python scripting.
+
+
+## `/py`
+
+Allows running Python expressions. This is not presently very useful and
+requires an overhaul. Be aware you must escape quotes.

--- a/user-guide/src/config.md
+++ b/user-guide/src/config.md
@@ -1,0 +1,111 @@
+# Configuration
+
+**TODO: Write more about config**
+
+## Where is my config file?
+
+This depends on your OS, but will generally be where applications keep their
+configuration:
+
+| OS      | Config dir                                                           |
+|---------|----------------------------------------------------------------------|
+| Linux   | `$HOME/.config/mudpuppy/config.toml`                                 |
+| MacOS   | `/Users/$USERNAME/Library/Application Support/mudpuppy/config.toml`  |
+| Windows | `C:\Users\$USER\AppData\Roaming\mudpuppy\config.toml`                |
+
+You can also find this directory from within Mudpuppy by running:
+
+```
+/py mudpuppy_core.config_dir()
+```
+
+Or from a Python script with:
+
+```python
+from mudpuppy_core import mudpuppy_core
+path = mudpuppy_core.config_dir()
+```
+
+## Example
+
+```toml
+[[muds]]
+name = "DuneMUD (TLS)"
+host = "dunemud.net"
+port = 6788
+tls = "Enabled"
+
+[[muds]]
+name = "DunemUD (Telnet)"
+host = "dunemud.net"
+port = 6789
+tls = "Disabled"
+
+[[muds]]
+name = "Custom"
+host = "dunemud.net"
+no_tcp_keepalive = true
+hold_prompt = false
+echo_input = false
+no_line_wrap = true
+debug_gmcp = true
+splitview_percentage = 50
+splitview_margin_horizontal = 0
+splitview_margin_vertical = 0
+
+# Default key bindings for the MUD list.
+[keybindings.MudList.Up]
+MudListPrev = {}
+[keybindings.MudList.Down]
+MudListNext = {}
+[keybindings.MudList.Enter]
+MudListConnect = {}
+[keybindings.MudList."<Ctrl-p>"]
+TabPrev = {}
+[keybindings.MudList."<Ctrl-n>"]
+TabNext = {}
+[keybindings.MudList.q]
+Quit = {}
+[keybindings.MudList.x]
+Quit = {}
+[keybindings.MudList."<Ctrl-d>"]
+Quit = {}
+[keybindings.MudList."<Ctrl-c>"]
+Quit = {}
+[keybindings.MudList."<Ctrl-x>"]
+Quit = {}
+
+# Default key bindings for MUD sessions.
+[keybindings.Mud."<Ctrl-p>"]
+TabPrev = {}
+[keybindings.Mud."<Ctrl-n>"]
+TabNext = {}
+[keybindings.Mud."<Alt-p>"]
+TabSwapLeft = {}
+[keybindings.Mud."<Alt-n>"]
+TabSwapRight = {}
+[keybindings.Mud."<Ctrl-d>"]
+Quit = {}
+[keybindings.Mud."<Ctrl-c>"]
+Quit = {}
+[keybindings.Mud."<Ctrl-q>"]
+Quit = {}
+[keybindings.Mud."<Ctrl-x>"]
+TabClose = {}
+[keybindings.Mud."F2"]
+ToggleInputEcho = {}
+[keybindings.Mud."F3"]
+ToggleLineWrap = {}
+[keybindings.Mud."Up"]
+HistoryPrevious = {}
+[keybindings.Mud."Down"]
+HistoryNext = {}
+[keybindings.Mud."PageUp"]
+ScrollUp = {}
+[keybindings.Mud."PageDown"]
+ScrollDown = {}
+[keybindings.Mud."<Shift-Home>"]
+ScrollTop = {}
+[keybindings.Mud."<Shift-End>"]
+ScrollBottom = {}
+```

--- a/user-guide/src/introduction.md
+++ b/user-guide/src/introduction.md
@@ -1,1 +1,21 @@
 # Introduction
+
+Mudpuppy is a terminal [MUD] client with a customizable interface and Python
+scripting.
+
+This _work-in-progress_ user manual aims to help you understand and use
+Mudpuppy. While Mudpuppy is a prototype, you may ask questions in [our Discord
+server] provided you understand the project is deeply in-flux.
+
+<div class="warning">
+Documentation is sparse and there is <strong>NO</strong> stability guarantee.
+Everything is subject to change without notice.
+
+Mudpuppy should work for a variety of MUD/MUSH/MUX/MUCK games, but it has
+primarily been tested with LP-style MUDs.
+
+Here be dragons^H^H^H^H^H^H^Hrabid saber-toothed mudpuppys.
+</div>
+
+[MUD]: https://en.wikipedia.org/wiki/Multi-user_dungeon
+[our Discord server]: https://discord.gg/bRadchaGFq

--- a/user-guide/src/logging.md
+++ b/user-guide/src/logging.md
@@ -1,0 +1,63 @@
+# Logging
+
+Mudpuppy can log at a variety of different verbosity levels. This is a very
+helpful mechanism when you're troubleshooting scripts, or trying to learn how
+Mudpuppy works.
+
+## Log location
+
+This depends on your OS, but will generally be where applications keep their
+non-configuration data:
+
+| OS      | Logfile                                                               |
+|---------|-----------------------------------------------------------------------|
+| Linux   | `$HOME/.local/share/mudpuppy/mudpuppy.log`                            |
+| MacOS   | `/Users/$USERNAME/Library/Application Support/mudpuppy/mudpuppy.log`  |
+| Windows | `C:\Users\$USER\AppData\Roaming\mudpuppy\mudpuppy.log`                |
+
+You can also find this directory from within Mudpuppy by running:
+
+```
+/py mudpuppy_core.data_dir()
+```
+
+Or from a Python script with:
+
+```python
+from mudpuppy_core import mudpuppy_core
+path = mudpuppy_core.data_dir()
+```
+
+## Log Level
+
+By default Mudpuppy logs at the "info" level. You can change the log level by
+setting an environment variable, or using the `--log-level` command line
+argument:
+
+```bash
+# Via env var:
+RUST_LOG=mudpuppy=trace mudpuppy
+
+# Or, via the CLI:
+mudpuppy --log-level=trace
+```
+
+The available log levels (in increasing level of verbosity/spam) are:
+
+1. error
+2. warn
+3. info
+4. debug
+5. trace
+
+# Python logging
+
+Your Python code can use the normal [logging] library and the log information
+will be sent to the same place as Mudpuppy's own logs.
+
+```python
+import logging
+logging.warning("hello from Python code!")
+```
+
+[logging]: https://docs.python.org/3/library/logging.html

--- a/user-guide/src/scripting/README.md
+++ b/user-guide/src/scripting/README.md
@@ -1,0 +1,75 @@
+# Scripting
+
+Python scripts placed in the Mudpuppy config directory are automatically loaded
+when Mudpuppy is started. This is the principle mechanism of scripting: putting
+Python code that interacts with Mudpuppy through the `mudpuppy` and
+`mudpuppy_core` packages in your config dir.
+
+## Where is my config directory?
+
+This depends on your OS, but will generally be where applications keep their
+configuration:
+
+| OS      | Config dir                                                |
+|---------|-----------------------------------------------------------|
+| Linux   | `$HOME/.config/mudpuppy/`                                 |
+| MacOS   | `/Users/$USERNAME/Library/Application Support/mudpuppy/`  |
+| Windows | `C:\Users\$USER\AppData\Roaming\mudpuppy\`                |
+
+You can also find this directory from within Mudpuppy by running:
+
+```
+/py mudpuppy_core.config_dir()
+```
+
+Or from a Python script with:
+
+```python
+from mudpuppy_core import mudpuppy_core
+path = mudpuppy_core.config_dir()
+```
+
+## Mudpuppy packages
+
+Your Python scripts can `import mudpuppy` and `import mudpuppy_core` to get
+access to helpful interfaces for interacting with Mudpuppy and MUDs.
+
+In general `mudpuppy_core` has low-level APIs, and helpful type definitions. On
+the other hand `mudpuppy` has higher-level APIs, such as decorators for making
+triggers/aliases/etc.
+
+**TODO: API documentation auto-generated from the Python should be linked
+here**.
+
+## Async
+
+Remember that Mudpuppy is **asynchronous**: most callbacks will need to be
+defined `async`, and you will need to `await` most operations on the
+`mudpuppy_core` interface.
+
+```python
+# Correct:
+@trigger(
+    mud_name="Dune",
+    pattern="^Soldier died.$",
+)
+async def bloodgod(session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups):
+    await mudpuppy_core.send(session_id, "say blood for the blood god!")
+```
+
+It is an error to forget to define your functions with the `async` keyword, or
+to forget to `await` async APIs like `mudpuppy_core.send()`:
+
+```python
+# INCORRECT (no 'async' on def, no 'await' for send):
+@trigger(
+    mud_name="Dune",
+    pattern="^Soldier died.$",
+)
+def bloodgod(session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups):
+    mudpuppy_core.send(session_id, "say blood for the blood god!")
+```
+
+Mudpuppy will do its best to catch these errors for you, but it's helpful to
+keep in mind.
+

--- a/user-guide/src/scripting/aliases.md
+++ b/user-guide/src/scripting/aliases.md
@@ -1,0 +1,109 @@
+# Aliases
+
+Aliases match **input** you send to the MUD. When the input matches an alias'
+pattern, the alias callback will be executed.
+
+* Aliases can be used for something as simple as expanding "e" to "east", or for
+more complex actions like making an HTTP request.
+
+* Aliases can be added so that they're only available for MUDs with a certain
+name, or so that they're available for all MUDs you connect to.
+
+* The line that matched the alias, as well as any regexp groups in the pattern are
+provided to the alias callback function alongside the `SessionId` of the MUD.
+
+## Basic global alias
+
+To make a basic alias that would expand the input "e" to "east" for all MUDs you
+can add this to a mudpuppy Python script:
+
+```python
+from mudpuppy import alias
+from mudpuppy_core import mudpuppy_core, SessionId, AliasId
+
+@alias(pattern="^e$", name="Quick East", expansion="east")
+async def quick_east(_session_id: SessionId, _alias_id: AliasId, _line: str, _groups):
+    pass
+```
+
+Providing `expansion` is a short-cut for "expanding" the input that was matched
+by the pattern, by replacing it with the `expansion` value. The above example is
+equivalent to the more verbose:
+
+```python
+@alias(pattern="^e$", name="Quick East")
+async def quick_east(session_id: SessionId, _alias_id: AliasId, _line: str, _groups):
+    await mudpuppy_core.send_line(session_id, "east")
+```
+
+## Per-MUD alias
+
+Here's an example of an alias that's only defined when you connect to a MUD
+named "Dune".
+
+It also demonstrates how to use a match group and the convenience
+of async aliases for doing things like "waiting a little bit" without blocking
+the client, or needing to use a separate timer.
+
+It will match input like "kill soldier", pass the command through to the game,
+and then also wait 5 seconds before issuing the command "headbutt soldier".
+
+```python
+import logging
+import asyncio
+from mudpuppy import alias
+from mudpuppy_core import mudpuppy_core, SessionId, AliasId
+
+
+@alias(mud_name="Dune", pattern="^kill (.*)$", name="Kill and headbutt")
+async def kill_headbutt(session_id: SessionId, _alias_id: AliasId, line: str, groups):
+    # Send through the original line so that we actually start combat in-game
+    # with the 'kill' command.
+    await mudpuppy_core.send_line(session_id, line)
+
+    # Wait for a little bit, and then give them a headbutt!
+    target = groups[0]
+    logging.info(f"building up momentum for a headbutt attack on {target}")
+
+    await asyncio.sleep(5)
+    await mudpuppy_core.send_line(session_id, f"headbutt {target}")
+```
+
+If you wanted to have this alias also available on MUDs named "DevDune" and
+"Dune (Alt)" the `mud_name` can be changed to a list:
+
+```python
+@alias(mud_name=["Dune","DevDune","Dune (alt)"], pattern="^kill (.*)$", name="Kill and headbutt")
+async def kill_headbutt(session_id: SessionId, _alias_id: AliasId, line: str, groups):
+    ...
+```
+
+## Alias info
+
+You can use the `AliasId` passed to the alias handler to access information
+about the alias, like how many times it has matched.
+
+This can be used for things like disabling an alias after a certain number of
+usages:
+
+```python
+from mudpuppy import alias
+from mudpuppy_core import mudpuppy_core, SessionId, AliasId, OutputItem
+
+@alias(pattern="^backstab$", name="Backstab limiter")
+async def backstab(session_id: SessionId, alias_id: AliasId, line: str, _groups):
+    alias_info = await mudpuppy_core.get_alias(session_id, alias_id)
+
+    # Too many backstabs this session!
+    hits = alias_info.config.hit_count
+    if hits > 10:
+        msg = f"backstabbed {hits} times already. Ignoring cmd."
+        logging.info(msg)
+        await mudpuppy_core.add_output(
+            session_id, OutputItem.failed_command_result(msg)
+        )
+        return
+
+    # Do the backstab
+    await mudpuppy_core.send_line(session_id, line)
+```

--- a/user-guide/src/scripting/custom_commands.md
+++ b/user-guide/src/scripting/custom_commands.md
@@ -1,0 +1,50 @@
+# Custom Commands
+
+Mudpuppy comes with a number of [built-in commands][commands]. You can also have
+your Python scripts add new custom commands. This is an attractive alternative
+to [aliases] when you want to support parse command-line arguments and flags.
+
+The default command prefix is `/` but can be altered in configuration.
+
+[commands]: ../commands.md
+[aliases]: aliases.md
+
+## Simple command
+
+Commands are created by extending the `Command` class and registering the
+command for a specific session with `commands.add_command()`.
+
+Your command's `__init__()` should call the `super().__init__` with:
+
+1. The command's name.
+2. The session ID.
+2. The command's main func.
+3. A description of the command.
+
+Here's a simple command that when `/simple` is run, will log a message.
+
+```python
+import logging
+from mudpuppy_core import SessionId, Event
+from commands import Command, add_command
+
+@on_new_session()
+async def setup(event: Event):
+    add_command(event.id, SimpleCmd(event.id))
+
+
+class SimpleCmd(Command):
+    def __init__(self, session: SessionId):
+        super().__init__("simple", session, self.simple, "A simple command example")
+
+    async def simple(self, sesh_id: SessionId, _args: Namespace):
+        logging.debug("Hello world!")
+
+```
+
+## Command-line args
+
+To define a command that takes command-line args and has sub-commands look at
+existing examples of built-in commands like [/trigger].
+
+[/trigger]: https://github.com/mudpuppy-rs/mudpuppy/blob/main/mudpuppy/python/cmd_trigger.py

--- a/user-guide/src/scripting/output.md
+++ b/user-guide/src/scripting/output.md
@@ -1,0 +1,64 @@
+# Output
+
+Because Mudpuppy is a complex terminal UI (TUI) you can't simply
+`print("hello")` to display output. In fact, if you do so it'll print overtop of
+the TUI and result in visual corruption.
+
+Instead you can should `OutputItem` instances to a specific session's output buffer
+for information you want to display, or use [logging] for debug information.
+
+Presently only the **low-level** API/types are available. In the future there
+will be helpers to make this less painful :-)
+
+[logging]: ../logging.md
+
+## Adding Output
+
+Output can be added using `mudpuppy_core.add_output()` and providing both the
+`SessionId` to add the output to, and an `OutputItem` to add. Remember this is
+an async operation so you'll need to `await`!
+
+```python
+from mudpuppy_core import mudpuppy_core, OutputItem
+
+await mudpuppy_core.add_output(
+    sesh_id, OutputItem.command_result("This was a test")
+)
+```
+
+## Output Item Types
+
+There are several `OutputItem` types you can construct to use with
+`add_output()`:
+
+1. `OutputItem.command_result(msg)` - for constructing output that should be
+   rendered as separate from game output. Generally this is used when the 
+   operation being described was successful. 
+
+2. `OutputItem.failed_command_result(msg)` - similar to above, but for
+   operations that failed and should be displayed as an error result.
+
+3. `OutputItem.mud_line(line)` - for displaying output as if it came from the MUD. You'll
+   need to construct a `MudLine` as the argument. E.g.:
+
+```python
+from mudpuppy_core import MudLine, OutputItem
+
+item = output_item.mud_line(MudLine(b"Some fake MUD output!"))
+```
+
+There is also `OutputItem.prompt()` and `OutputItem.held_prompt()` that take
+a `MudLine` but treat it as a prompt, or held prompt.
+
+4. `OutputItem.input(line)` - for displaying input as if it came from the user.
+   You'll need to construct a `InputLine` for the argument. E.g.:
+
+```python
+from mudpuppy_core import InputLine, OutputItem
+
+line = InputLine("some fake input!")
+line.original = "FAKE!"
+item = output_item.input(line)
+```
+
+5. `OutputItem.debug(msg)` - for displaying debug information.

--- a/user-guide/src/scripting/prompts.md
+++ b/user-guide/src/scripting/prompts.md
@@ -1,0 +1,62 @@
+# Prompts
+
+Mudpuppy attempts to detect what is/isn't a prompt in a few ways (listed in
+order of how reliable they are):
+
+1. Negotiating support for the telnet "EOR" option, and expecting prompts to be
+   terminated with EOR.
+2. Seeing lines that end with telnet "GA", and assuming they are prompts.
+3. Seeing lines that end without `\r\n`, after a short timeout expires to ensure
+   it wasn't a partial line.
+
+It is not presently possible to set the prompt handling mode manually, it is
+determined based on whether the MUD supports the telnet options mentioned above.
+Similarlyh it isn't presently possible to change the prompt flushing timeout for
+unterminated prompt mode. In the future this will be more flexible.
+
+## Prompt Event Handlers
+
+To write a handler that fires for every prompt line for any MUD, write:
+
+```python
+from mudpuppy_core import EventType, Event, SessionId, MudLine
+from mudpuppy import on_event
+
+@on_event(EventType.Prompt)
+async def prompt_handler(event: Event):
+    session_id: SessionId = event.id
+    prompt_line: MudLine = event.prompt
+    logging.debug(f"session {session_id} got prompt line {prompt_line}")
+```
+
+Similar to [aliases], [triggers], and [timers] it's also possible to write
+a handler that only fires for prompt events for specifically named MUDs.
+
+```python
+@on_event(EventType.Prompt)
+async def prompt_handler(event: Event):
+    session_id: SessionId = event.id
+    prompt_line: MudLine = event.prompt
+    logging.debug(f"session {session_id} got prompt line {prompt_line}")
+```
+
+Similar to [aliases], [triggers], and [timers] it's also possible to write
+a handler that only fires for prompt events for specifically named MUDs.
+
+```python
+@on_mud_event(["Dune", "OtherMud"], EventType.Prompt)
+async def prompt_handler(event: Event):
+    ...
+```
+
+
+## Prompt Triggers
+
+`MudLine`'s that are detected as a prompt have the `prompt` field set to `True`.
+See [triggers] for more information on how to write triggers that only match
+prompt lines.
+
+This is genereally more useful if you want to only match certain prompt
+patterns, or to gag prompts.
+
+[triggers]: triggers.md

--- a/user-guide/src/scripting/timers.md
+++ b/user-guide/src/scripting/timers.md
@@ -1,0 +1,45 @@
+# Timers
+
+Timers run on a fixed interval. When the timer interval runs out, the timer
+callback is invoked and then the timer is reset to wait for another interval.
+
+* Timers are great for running an action on a regular cadence, like sending
+  a "save" command every 15 minutes.
+
+* Timers can be configured to only run a certain number of times. This can be
+  helpful for something like running a "heal" command 3 times, with a 10 second
+  wait between them.
+
+## Basic global timer
+
+To make a basic timer that runs every 2 minutes, 10 seconds you can add this to
+a mudpuppy Python script.
+
+Since global timers run without being tied to a specific MUD they are provided
+the currently focused active session ID (if there is one!) as an argument:
+
+```python
+@timer(name="Party Timer", seconds=10, minutes=2)
+async def party(timer_id: TimerId, session_id: Optional[SessionId]):
+    logging.debug(f"2m10s timer fired: {timer_id}!")
+    if session_id is not None:
+        await mudpuppy_core.send_line(session_id, "say PARTY TIME!!!")
+```
+
+## Max ticks
+
+Here's an example of a timer that's only defined when you connect to a MUD
+named "Dune", and that only runs 3 times total (with a 10s wait between each
+run).
+
+```python
+@timer(mud_name="Dune", name="Heal Timer", seconds=10, max_ticks=3)
+async def heal_timer(_timer_id: TimerId, session_id: SessionId):
+    await mudpuppy_core.send_line(session_id, "heal")
+```
+
+Like [aliases] and [triggers] you can also pass a list of names to `mud_name`
+like `mud_name=["Dune", "OtherMUD"]`.
+
+[aliases]: aliases.md
+[triggers]: triggers.md

--- a/user-guide/src/scripting/triggers.md
+++ b/user-guide/src/scripting/triggers.md
@@ -1,0 +1,126 @@
+# Triggers
+
+Triggers match a line of **output** sent by the MUD. When the output matches an
+trigger's pattern, the trigger callback will be executed.
+
+* Triggers can be used for something as simple as sending "light torch" whenever
+the game sends the line "It is too dark to see." or for more complex actions
+like automatically making an HTTP request to look up the name of an item in
+a database when you see it on the ground.
+
+* Triggers can be added so that they're only available for MUDs with a certain
+name, or so that they're available for all MUDs you connect to.
+
+* The line that matched the trigger, as well as any regexp groups in the pattern are
+provided to the trigger callback function alongside the `SessionId` of the MUD.
+
+<div class="warning">
+Note that all triggers are matched a line at a time. Multi-line triggers are not
+yet supported.
+</div>
+
+## Basic global trigger
+
+To make a basic trigger that would match the line "Your ship has landed." and
+automatically send "enter ship" you can add this to a mudpuppy Python script:
+
+```python
+@trigger(
+    name="quick ship",
+    pattern=r"^Your ship has landed\.$"
+    expansion="enter ship",
+)
+async def quick_ship(_session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups):
+    pass
+```
+
+Providing expansion is a short-cut for "expanding" the input that was matched by
+the pattern, by replacing it with the expansion value. The above example is
+equivalent to the more verbose:
+
+```python
+@trigger(
+    name="quick ship",
+    pattern=r"^Your ship has landed\.$"
+)
+async def quick_ship(session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups):
+    await mudpuppy_core.send_line(session_id, "enter ship")
+```
+
+## Per-MUD triggers
+
+Like [aliases](aliases.md) you can define triggers for only certain MUDs by
+providing a `mud_name` string, or list of strings:
+
+```python
+@trigger(
+    name="quick ship",
+    mud_name=["Dune", "DevDune"],
+    pattern=r"^Your ship has landed\.$",
+    expansion="enter ship",
+)
+async def quick_ship(_session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups):
+    pass
+)
+```
+
+## Output gags
+
+If you want to silence, supress or "gag" lines of output you can write a trigger
+that matches the lines you wish to gag, setting `gag=True` in the trigger
+decorator:
+
+```python
+@trigger(
+    name="silence save spam",
+    pattern=r"^(?:Autosave)|(?:Your character has been saved safely)\.$",
+    gag=True
+)
+async def quiet_saves(_session_id: SessionId, _trigger_id: TriggerId, _line: str, _groups):
+    pass
+)
+```
+
+## Matching prompt lines
+
+You can also create triggers that only match prompt lines by specifying
+`prompt=True` in the `@trigger` decorator. This can also be combined with
+`gag=True` to gag matched prompts.
+
+See [prompts] for more information on how prompts are detected.
+
+```python
+import logging
+
+@trigger(
+    name="Gag login prompts",
+    prompt=True,
+    gag=True,
+    pattern=r"(?:Enter your username: )|(?:Password: )"
+)
+async def gag_login(_session_id: SessionId, _trigger_id: TriggerId, line: str, _groups: Any):
+    logging.debug(f"gagged login prompt: {line}")
+```
+
+[prompts]: prompts.md
+
+## Matching ANSI
+
+By default triggers are created with `strip_ansi=True`. Lines of text will have
+any ANSI colour codes removed before evaluating the trigger pattern.
+
+If you want to write a trigger that matches on ANSI you need to specify
+`strip_ansi=False` in the `@trigger` decorator:
+
+```python
+import logging
+
+@trigger(
+    name="Match bold",
+    strip_ansi=False,
+    pattern=r"\033\[[\d]+;1m(.*)\033\[0m",
+)
+async def quiet_saves(_session_id: SessionId, trigger_id: TriggerId, _line: str, groups):
+    logging.info(f"quiet_saves({trigger_id}) matched bold text: {groups[0]}")
+)
+```


### PR DESCRIPTION
Some new content (e.g. on `OutputItems`) is added along the way. There's still a lot more polish required but having the content out of the `README` and in a more structured format (that's easy to view online!) gives us a good place to start.