### PR TITLE
python: print() builtin -> mudpuppy_core.print()

### DIFF
--- a/mudpuppy/python/history.py
+++ b/mudpuppy/python/history.py
@@ -107,7 +107,7 @@ async def shortcut(event: Event):
             mudpuppy_core.set_input(event.id, line.original)
 
     input = await mudpuppy_core.get_input(event.id)
-    logging.info(f"val is: {input}")
+    logging.debug(f"val is: {input}")
 
 
 @on_new_session()

--- a/user-guide/src/scripting/output.md
+++ b/user-guide/src/scripting/output.md
@@ -1,22 +1,31 @@
 # Output
 
-Because Mudpuppy is a complex terminal UI (TUI) you can't simply
-`print("hello")` to display output. In fact, if you do so it'll print overtop of
-the TUI and result in visual corruption.
-
-Instead you can should `OutputItem` instances to a specific session's output buffer
-for information you want to display, or use [logging] for debug information.
+Mudpuppy displays outputs per-MUD in a special output buffer. Your Python code
+can add items to be displayed through the `mudpuppy_core` API, or for simple
+debugging, using `print()`.
 
 Presently only the **low-level** API/types are available. In the future there
 will be helpers to make this less painful :-)
 
 [logging]: ../logging.md
 
+## Debug Output
+
+For simple debug output you can use `print()`. It will convert each line of what
+would have been written to stdout into `OutputItem.debug()` instances that get
+added to the currently active session. If called when there is no active
+session, nothing will be displayed - prefer `logging` for this use-case.
+
+You can also use `print()` from `/py` but you must carefully escape the input:
+```
+/py print(\"this is a test\\nhello!\")
+```
+
 ## Adding Output
 
-Output can be added using `mudpuppy_core.add_output()` and providing both the
-`SessionId` to add the output to, and an `OutputItem` to add. Remember this is
-an async operation so you'll need to `await`!
+Other kinds of output can be added using `mudpuppy_core.add_output()` and
+providing both the `SessionId` to add the output to, and an `OutputItem` to add.
+Remember this is an async operation so you'll need to `await`!
 
 ```python
 from mudpuppy_core import mudpuppy_core, OutputItem


### PR DESCRIPTION
This branch adds a new `mudpuppy_core.print()` fn that has a Python fn signature matching the `print()` built-in.

Crucially, the `mudpuppy_core` version doesn't write to stdout and instead converts each line of what _would_ have been printed to stdout into debug `OutputItem`'s appended to the currently active sessions's output buffer.

As a result it's now safe to use from `/py` with appropriate quoting:
```
/py print(\"This is a test!\\nDebug debug debug!\")
```

Scripts can also invoke `print("...")` with normal Python syntax, but care should be taken to make sure there's an active session. E.g. Python code that runs when the client starts before any sessions are started that uses `print()` will not display any output. Prefer `logging` for that use-case.

Resolves https://github.com/mudpuppy-rs/mudpuppy/issues/16