### PR TITLE
mudbuffer: replace \t prior to rendering

### DIFF
--- a/mudpuppy/src/tui/mudbuffer.rs
+++ b/mudpuppy/src/tui/mudbuffer.rs
@@ -214,11 +214,13 @@ impl buffer::Item for output::Item {
         Ok(match self {
             Self::Mud { line: text }
             | Self::Prompt { prompt: text }
-            | Self::HeldPrompt { prompt: text } => {
-                String::from_utf8_lossy(&text.raw).to_string().into_text()?
-            }
+            | Self::HeldPrompt { prompt: text } => String::from_utf8_lossy(&text.raw)
+                .to_string()
+                .replace('\t', "    ")
+                .into_text()?,
             Self::PreviousSession { line, .. } => String::from_utf8_lossy(&line.raw)
                 .to_string()
+                .replace('\t', "    ")
                 .into_text()?
                 .style(Style::default().add_modifier(Modifier::DIM)),
             Self::Input { line, .. } => {


### PR DESCRIPTION
For some reason the `\t` character in MUD output causes weird glitchy rendering in the mudbuffer after it's run through the `ansi-to-tui` crate's conversion to `ratatui::Text`.

We can work around this issue for now by replacing tabs with four literal spaces. It Works :tm: Ship it.

Resolves https://github.com/mudpuppy-rs/mudpuppy/issues/25