### PR TITLE
update pyo3 0.21 -> 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.74",
@@ -727,12 +727,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1094,7 +1088,7 @@ dependencies = [
  "notify",
  "pretty_assertions",
  "pyo3",
- "pyo3-asyncio-0-21",
+ "pyo3-async-runtimes",
  "pyo3-pylogger",
  "ratatui",
  "regex",
@@ -1343,15 +1337,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1360,24 +1354,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-asyncio-0-21"
+name = "pyo3-async-runtimes"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fde289486f7d5cee0ac7c20b2637a0657654681079cc5eedc90d9a2a79af1e5"
+source = "git+https://github.com/PyO3/pyo3-async-runtimes.git?rev=284bd36d0426a988026f878cae22abdb179795e6#284bd36d0426a988026f878cae22abdb179795e6"
 dependencies = [
  "futures",
  "once_cell",
  "pin-project-lite",
  "pyo3",
- "pyo3-asyncio-macros-0-21",
+ "pyo3-async-runtimes-macros",
  "tokio",
 ]
 
 [[package]]
-name = "pyo3-asyncio-macros-0-21"
+name = "pyo3-async-runtimes-macros"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5ffc4e987e866bf54b781235a6c3b91e7e67df14f73ce716625ee78728554a"
+source = "git+https://github.com/PyO3/pyo3-async-runtimes.git?rev=284bd36d0426a988026f878cae22abdb179795e6#284bd36d0426a988026f878cae22abdb179795e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1386,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1396,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1406,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1418,11 +1410,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -1806,7 +1798,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,8 @@ happy-eyeballs = { version = "0.2", default-features = false }
 human-panic = "2"
 notify = "6"
 pretty_assertions = "1"
-# TODO(XXX): update pyo3.
-pyo3 = { version = "0.21", features = ["experimental-async"] }
-pyo3-asyncio-0-21 = { version = "0.21", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.22", features = ["experimental-async", "py-clone"] }
+pyo3-async-runtimes = { version = "0.21", features = ["attributes", "tokio-runtime"] }
 pyo3-pylogger = "0.3"
 # TODO(XXX): update ratatui.
 ratatui = { version = "0.27", default-features = false }
@@ -79,3 +78,7 @@ strip = true
 
 [profile.dist]
 inherits = "release"
+
+[patch.crates-io]
+# TODO(@cpu): remove once pyo3-async-runtimes cuts a 0.22 release.
+pyo3-async-runtimes  = { git = 'https://github.com/PyO3/pyo3-async-runtimes.git', rev = '284bd36d0426a988026f878cae22abdb179795e6' }

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,13 @@
               inherit (mudpuppyCargoToml.package) name version;
               src = ./.;
               buildAndTestSubdir = "mudpuppy";
-              cargoLock.lockFile = ./Cargo.lock;
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+                outputHashes = {
+                  "pyo3-async-runtimes-0.21.0" =
+                    "sha256-+zMamQGI5xyEDc8356/fKKft+7ABS0a9EcwDa1L/mOc=";
+                };
+              };
               buildFeatures = features;
               buildInputs = runtimeDeps;
               nativeBuildInputs = buildDeps;

--- a/mudpuppy/Cargo.toml
+++ b/mudpuppy/Cargo.toml
@@ -27,7 +27,7 @@ happy-eyeballs = { workspace = true, features = ["tokio"] }
 notify = { workspace = true }
 human-panic = { workspace = true }
 pyo3 = { workspace = true }
-pyo3-asyncio-0-21 = { workspace = true }
+pyo3-async-runtimes = { workspace = true }
 pyo3-pylogger = { workspace = true }
 ratatui = { workspace = true, default-features = true, features = ["unstable-widget-ref"] }
 regex = { workspace = true }

--- a/mudpuppy/src/client/input.rs
+++ b/mudpuppy/src/client/input.rs
@@ -312,7 +312,7 @@ impl From<&str> for Input {
     }
 }
 
-#[pyclass]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub enum EchoState {
     #[default]

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -584,7 +584,7 @@ impl Client {
 
             if let Some(callback) = &trigger_config.callback {
                 trace!("preparing callback future for matches: {groups:?}");
-                futures.push(Box::pin(pyo3_asyncio_0_21::tokio::into_future(
+                futures.push(Box::pin(pyo3_async_runtimes::tokio::into_future(
                     callback
                         .call1(py, (session_id, trigger.id(), line.clone(), groups.clone()))?
                         .into_bound(py),
@@ -636,7 +636,7 @@ impl Client {
 
             if let Some(callback) = &alias_config.callback {
                 trace!("preparing callback future for matches: {groups:?}");
-                futures.push(Box::pin(pyo3_asyncio_0_21::tokio::into_future(
+                futures.push(Box::pin(pyo3_async_runtimes::tokio::into_future(
                     callback
                         .call1(py, (session_id, alias.id(), input.clone(), groups.clone()))?
                         .into_bound(py),

--- a/mudpuppy/src/main.rs
+++ b/mudpuppy/src/main.rs
@@ -4,7 +4,7 @@ use std::io::{self, IsTerminal};
 use clap::Parser;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::{PyResult, Python};
-use pyo3_asyncio_0_21::tokio as pyo3tokio;
+use pyo3_async_runtimes::tokio as pyo3tokio;
 use tokio::runtime;
 use tracing::{error, info, instrument};
 

--- a/mudpuppy/src/model.rs
+++ b/mudpuppy/src/model.rs
@@ -98,7 +98,7 @@ impl Display for Mud {
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize,
 )]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 #[allow(clippy::unsafe_derive_deserialize)] // No constructor invariants to uphold.
 pub enum Tls {
     #[default]
@@ -107,7 +107,7 @@ pub enum Tls {
     InsecureSkipVerify,
 }
 
-#[pyclass]
+#[pyclass(eq, eq_int)]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(clippy::unsafe_derive_deserialize)] // No constructor invariants to uphold.
@@ -307,7 +307,7 @@ impl Default for PromptMode {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum PromptSignal {
     EndOfRecord,
     GoAhead,
@@ -692,6 +692,7 @@ impl TimerConfig {
     ///
     /// If the duration pattern can't be recognized.
     #[new]
+    #[pyo3(signature = (name, duration_ms, callback, session_id=None))]
     pub fn new(
         name: String,
         duration_ms: u64,

--- a/mudpuppy/src/tui/layout.rs
+++ b/mudpuppy/src/tui/layout.rs
@@ -174,7 +174,7 @@ impl LayoutNode {
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
-#[pyclass(name = "Direction")]
+#[pyclass(name = "Direction", eq, eq_int)]
 pub enum PyDirection {
     Horizontal,
     #[default]
@@ -604,7 +604,7 @@ impl Display for BufferConfig {
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum BufferDirection {
     TopToBottom,
     #[default]


### PR DESCRIPTION
See the [migration guide](https://pyo3.rs/v0.22.0/migration.html) for more information.

We're presently using the `py-clones` opt-in feature to keep the pre-existing behaviour of cloneable pyclasses. Unfortunately these now panic at runtime if the GIL isn't held (ugh). I've done my best to catch these potential panic sites but no doubt missed one somewhere. In the future we should consider dropping this feature to avoid the footgun and find alternatives where required.

Another small wrinkle: the pyo3 <-> tokio async bridge library has been updated for PyO3 (now under a new name, `pyo3-async-runtimes`) but that support hasn't been released yet. Since we don't publish this app on crates.io it's not a big deal to take a cargo patch to use the unreleased code while we wait.

This brings support for Python 3.13 and should unbreak CI on ubuntu-latest.
