### PR TITLE
update ratatui/crossterm/notify to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "futures-core",
- "mio 1.0.2",
+ "mio",
  "parking_lot",
  "rustix",
  "serde",
@@ -898,9 +898,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
@@ -924,6 +924,15 @@ checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
 dependencies = [
  "quote",
  "syn 2.0.82",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1074,18 +1083,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
@@ -1150,21 +1147,30 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
  "bitflags 2.6.0",
- "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7393c226621f817964ffb3dc5704f9509e107a8b024b489cc2c1b217378785df"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1743,7 +1749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 1.0.2",
+ "mio",
  "signal-hook",
 ]
 
@@ -1921,7 +1927,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
+ "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "ansi-to-tui"
-version = "5.0.0-rc.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428c2992b874104caf39204b05bf89eab4ceefdd4fcb26caa6759906f547f8e8"
+checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
 dependencies = [
  "nom",
  "ratatui",
@@ -343,13 +343,14 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
 ]
@@ -444,16 +445,16 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "futures-core",
- "libc",
- "mio 0.8.11",
+ "mio 1.0.2",
  "parking_lot",
+ "rustix",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -524,6 +525,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "filetime"
@@ -906,6 +917,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,9 +975,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libredox"
@@ -968,6 +989,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1065,6 +1092,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -1106,7 +1134,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
  "webpki-roots",
 ]
 
@@ -1472,23 +1500,23 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
+ "indoc",
+ "instability",
  "itertools",
  "lru",
  "paste",
- "stability",
  "strum",
- "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1575,6 +1603,19 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustls"
@@ -1702,7 +1743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -1751,16 +1792,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn 2.0.82",
-]
 
 [[package]]
 name = "static_assertions"
@@ -2139,7 +2170,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -2147,6 +2178,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,13 @@ keywords = ["MUD", "telnet", "TUI", "terminal", "multiplayer"]
 description = "A terminal MUD client, scripted with Python"
 
 [workspace.dependencies]
-# TODO(XXX): update ansi-to-tui.
-ansi-to-tui = "5.0.0-rc.1"
+ansi-to-tui = "7"
 async-trait = "0.1"
 better-panic = "0.3"
 clap = "4"
 config = { version = "0.14", default-features = false }
 console-subscriber = "0.4"
-crossterm = { version = "0.27", default-features = false }
+crossterm = { version = "0.28", default-features = false }
 deref-derive = "0.1"
 directories = "5"
 futures = "0.3"
@@ -34,8 +33,7 @@ pretty_assertions = "1"
 pyo3 = { version = "0.22", features = ["experimental-async", "py-clone"] }
 pyo3-async-runtimes = { version = "0.21", features = ["attributes", "tokio-runtime"] }
 pyo3-pylogger = "0.3"
-# TODO(XXX): update ratatui.
-ratatui = { version = "0.27", default-features = false }
+ratatui = { version = "0.29", default-features = false }
 regex = "1"
 serde = "1"
 serde_json = "1"
@@ -51,8 +49,8 @@ tracing = "0.1"
 tracing-error = "0.2"
 tracing-subscriber = "0.3"
 unicode-segmentation = "1"
-# TODO(XXX): use version pinned by ratatui.
-unicode-width = "0.1"
+# See <https://github.com/ratatui/ratatui/issues/1271> for information about why Ratatui pins unicode-width
+unicode-width = "=0.2.0"
 webpki-roots = "0.26"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ directories = "5"
 futures = "0.3"
 happy-eyeballs = { version = "0.2", default-features = false }
 human-panic = "2"
-notify = "6"
+notify = "7"
 pretty_assertions = "1"
 pyo3 = { version = "0.22", features = ["experimental-async", "py-clone"] }
 pyo3-async-runtimes = { version = "0.21", features = ["attributes", "tokio-runtime"] }

--- a/mudpuppy/src/app.rs
+++ b/mudpuppy/src/app.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Formatter};
 use std::io::{self, stdout};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -207,7 +208,7 @@ impl App {
     fn draw(&mut self, state: &mut State, terminal: &mut Terminal<impl Backend>) {
         terminal
             .draw(|frame| {
-                let area = frame.size();
+                let area = frame.area();
 
                 frame.render_widget(Clear, area);
 
@@ -735,7 +736,7 @@ fn init_terminal() -> io::Result<Terminal<impl Backend>> {
     enable_raw_mode()?;
     stdout().execute(EnterAlternateScreen)?;
     // increase the cache size to avoid flickering for indeterminate layouts
-    Layout::init_cache(100);
+    Layout::init_cache(NonZeroUsize::new(100).unwrap());
     Terminal::new(CrosstermBackend::new(stdout()))
 }
 

--- a/mudpuppy/src/tui/buffer.rs
+++ b/mudpuppy/src/tui/buffer.rs
@@ -176,7 +176,7 @@ where
                     continue;
                 }
                 let symbol = if symbol.is_empty() { " " } else { symbol };
-                buf.get_mut(area.left() + x, area.top() + y)
+                buf[(area.left() + x, area.top() + y)]
                     .set_symbol(symbol)
                     .set_style(style);
                 x += u16::try_from(width)

--- a/mudpuppy/src/tui/input.rs
+++ b/mudpuppy/src/tui/input.rs
@@ -1,4 +1,4 @@
-use ratatui::layout::Rect;
+use ratatui::layout::{Position, Rect};
 use ratatui::prelude::{Color, Style};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
@@ -38,12 +38,12 @@ impl Input {
             .scroll((0, u16::try_from(scroll).unwrap_or_default()));
 
         frame.render_widget(input_text, *area);
-        frame.set_cursor(
-            area.x
-                + u16::try_from(input.visual_cursor().max(scroll) - scroll).unwrap_or_default()
-                + 1,
-            area.y + 1,
-        );
+
+        let cursor_x = area.x
+            + u16::try_from(input.visual_cursor().max(scroll) - scroll).unwrap_or_default()
+            + 1;
+
+        frame.set_cursor_position(Position::from((cursor_x, area.y + 1)));
         Ok(())
     }
 }


### PR DESCRIPTION
Jumping from ratatui 0.27 to [0.29](https://github.com/ratatui/ratatui/releases/tag/v0.29.0). This was relatively painless, and only required fixing a couple breaks/deprecation warns. Likely there are some other places that could be cleaned up using new features from 0.27+ but for now let's just get everything working as-is. The `ansi-to-tui` release is updated to match `ratatui` versions.

Crossterm gets bumped alongside to match Ratatui's req. We can't use the Ratatui re-export because we want to activate some features on crossterm ourselves (event-stream, bracketed-paste, etc).

Lastly, `notify` is updated to [7.0.0](https://github.com/notify-rs/notify/releases/tag/notify-7.0.0) - no changes req'd.