### PR TITLE
stubs, stubs, stubs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,7 @@
                   enable = true;
                 };
                 ruff.enable = true;
+                ruff-format.enable = true;
                 pyright.enable = false; # TODO(XXX): Restore after fixing stubs.
                 nightly-fmt = (cargo-check "cargo-fmt" "fmt --check");
                 nightly-clippy = (cargo-check "cargo-clippy"

--- a/flake.nix
+++ b/flake.nix
@@ -131,7 +131,7 @@
                 };
                 ruff.enable = true;
                 ruff-format.enable = true;
-                pyright.enable = false; # TODO(XXX): Restore after fixing stubs.
+                pyright.enable = true;
                 nightly-fmt = (cargo-check "cargo-fmt" "fmt --check");
                 nightly-clippy = (cargo-check "cargo-clippy"
                   "clippy --all-targets --all-features -- -D warnings");

--- a/mudpuppy/python/cmd_alias.py
+++ b/mudpuppy/python/cmd_alias.py
@@ -129,4 +129,5 @@ class AliasCmd(Command):
 
 @on_new_session()
 async def setup_session(event: Event):
+    assert isinstance(event, Event.NewSession)
     add_command(event.id, AliasCmd(event.id))

--- a/mudpuppy/python/cmd_misc.py
+++ b/mudpuppy/python/cmd_misc.py
@@ -59,6 +59,7 @@ class ReloadCmd(Command):
 
 @on_new_session()
 async def setup(event: Event):
+    assert isinstance(event, Event.NewSession)
     add_command(event.id, ConnectCmd(event.id))
     add_command(event.id, DisconnectCmd(event.id))
     add_command(event.id, QuitCmd(event.id))

--- a/mudpuppy/python/cmd_py.py
+++ b/mudpuppy/python/cmd_py.py
@@ -43,11 +43,12 @@ class Python(Command):
                 sesh_id, OutputItem.command_result(repr(result))
             )
         except Exception as e:
-            mudpuppy_core.add_output(
+            await mudpuppy_core.add_output(
                 sesh_id, OutputItem.failed_command_result(f"Error running code: {e}")
             )
 
 
 @on_new_session()
 async def setup(event: Event):
+    assert isinstance(event, Event.NewSession)
     add_command(event.id, Python(event.id))

--- a/mudpuppy/python/cmd_status.py
+++ b/mudpuppy/python/cmd_status.py
@@ -50,6 +50,7 @@ class StatusCmd(Command):
             return items
 
         info = status.info
+        assert isinstance(info, StreamInfo.Tcp) or isinstance(info, StreamInfo.Tls)
         items.append(OutputItem.command_result(f"IP: {info.ip}"))
         items.append(OutputItem.command_result(f"Port: {info.port}"))
         if not isinstance(info, StreamInfo.Tls):
@@ -65,4 +66,5 @@ class StatusCmd(Command):
 
 @on_new_session()
 async def setup(event: Event):
+    assert isinstance(event, Event.NewSession)
     add_command(event.id, StatusCmd(event.id))

--- a/mudpuppy/python/cmd_timer.py
+++ b/mudpuppy/python/cmd_timer.py
@@ -150,4 +150,5 @@ class TimerCmd(Command):
 
 @on_new_session()
 async def setup_session(event: Event):
+    assert isinstance(event, Event.NewSession)
     add_command(event.id, TimerCmd(event.id))

--- a/mudpuppy/python/cmd_trigger.py
+++ b/mudpuppy/python/cmd_trigger.py
@@ -167,4 +167,5 @@ class TriggerCmd(Command):
 
 @on_new_session()
 async def setup(event: Event):
+    assert isinstance(event, Event.NewSession)
     add_command(event.id, TriggerCmd(event.id))

--- a/mudpuppy/python/history.py
+++ b/mudpuppy/python/history.py
@@ -80,6 +80,7 @@ def get_history(session_id: int) -> Optional[History]:
 
 @on_event(EventType.InputLine)
 async def input_sent(event: Event):
+    assert isinstance(event, Event.InputLine)
     if history.get(event.id) is None:
         return
     history[event.id].add(event.input)
@@ -87,6 +88,7 @@ async def input_sent(event: Event):
 
 @on_event(EventType.Shortcut)
 async def shortcut(event: Event):
+    assert isinstance(event, Event.Shortcut)
     if event.shortcut == Shortcut.HistoryNext:
         line = history[event.id].next()
     elif event.shortcut == Shortcut.HistoryPrevious:
@@ -96,15 +98,15 @@ async def shortcut(event: Event):
 
     logging.info(f"populating {event.id} input with: {line}")
     if line is None:
-        mudpuppy_core.set_input(event.id, "")
+        await mudpuppy_core.set_input(event.id, "")
     else:
         # TODO(XXX): make this configurable
         if line.scripted:
             return
         if line.original is None:
-            mudpuppy_core.set_input(event.id, line.sent)
+            await mudpuppy_core.set_input(event.id, line.sent)
         else:
-            mudpuppy_core.set_input(event.id, line.original)
+            await mudpuppy_core.set_input(event.id, line.original)
 
     input = await mudpuppy_core.get_input(event.id)
     logging.debug(f"val is: {input}")
@@ -112,6 +114,7 @@ async def shortcut(event: Event):
 
 @on_new_session()
 async def setup(event: Event):
+    assert isinstance(event, Event.NewSession)
     sesh_info = await mudpuppy_core.session_info(event.id)
     history[event.id] = History(sesh_info)
 

--- a/mudpuppy/python/layout.py
+++ b/mudpuppy/python/layout.py
@@ -74,7 +74,7 @@ class LayoutManager:
         constraint: Constraint,
         direction: Direction = Direction.Vertical,
         margin: int = 0,
-        buffer_config: BufferConfig = None,
+        buffer_config: Optional[BufferConfig] = None,
     ) -> Optional[BufferId]:
         if section_name == "" or new_section_name == "":
             raise ValueError("section names must not be empty")
@@ -118,8 +118,8 @@ class LayoutManager:
         new_constraint: Constraint,
         direction: Direction = Direction.Vertical,
         margin: int = 0,
-        buffer_config: BufferConfig = None,
-    ):
+        buffer_config: Optional[BufferConfig] = None,
+    ) -> Optional[BufferId]:
         if section_name == "" or new_section_name == "":
             raise ValueError("section names must not be empty")
 
@@ -160,11 +160,13 @@ class LayoutManager:
 
 @on_new_session()
 async def setup_session(event: Event):
+    assert isinstance(event, Event.NewSession)
     await manager.on_new_session(event.info)
 
 
 @on_event(EventType.ResumeSession)
 async def on_resume(event: Event):
+    assert isinstance(event, Event.ResumeSession)
     info = await mudpuppy_core.session_info(event.id)
     await manager.on_new_session(info)
 

--- a/mudpuppy/python/mudpuppy.py
+++ b/mudpuppy/python/mudpuppy.py
@@ -25,7 +25,7 @@ logging.debug(f"Mudpuppy Python module loaded: {mudpuppy_core}")
 
 
 # It's easy to forget to add the async keyword to a function that should be async.
-def ensure_async(handler: Callable) -> None:
+def __ensure_async(handler: Callable) -> None:
     if not inspect.iscoroutinefunction(handler):
         raise TypeError(
             f"The handler function '{handler.__name__}' must be an async function"
@@ -34,7 +34,7 @@ def ensure_async(handler: Callable) -> None:
 
 def on_event(event_type: Union[EventType, List[EventType]], module=None):
     def on_event_decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
         handler_module = module or handler.__module__
         if isinstance(event_type, list):
             for et in event_type:
@@ -48,7 +48,7 @@ def on_event(event_type: Union[EventType, List[EventType]], module=None):
 
 def on_gmcp(package: str, module=None):
     def on_gmcp_decorator(handler: GmcpHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_event(EventType.GmcpMessage, module=module or handler.__module__)
         async def gmcp_message_wrapper(event: Event):
@@ -65,7 +65,7 @@ def on_new_session(module=None):
         logging.debug(
             f"setting up on_new_session handler for {module} ({handler.__module__}) -> {handler.__name__}"
         )
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_event(EventType.NewSession, module=module or handler.__module__)
         async def on_new_session_decorator(event: Event):
@@ -81,7 +81,7 @@ def on_new_session_or_reload(module=None):
         logging.debug(
             f"setting up on_new_session_or_reload handler for {module} ({handler.__module__}) -> {handler.__name__}"
         )
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_event(
             [EventType.NewSession, EventType.ResumeSession],
@@ -97,7 +97,7 @@ def on_new_session_or_reload(module=None):
 
 def on_connected(module=None):
     def decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_event(EventType.Connection, module=module or handler.__module__)
         async def on_connected_decorator(event: Event):
@@ -111,7 +111,7 @@ def on_connected(module=None):
 
 def on_disconnected(module=None):
     def decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_event(EventType.Connection, module=module or handler.__module__)
         async def on_disconnected_decorator(event: Event):
@@ -129,7 +129,7 @@ def on_mud_event(
     module=None,
 ):
     def on_mud_event_decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_event(event_type, module=module or handler.__module__)
         async def on_mud_event_wrapper(event: Event):
@@ -151,7 +151,7 @@ def on_mud_event(
 
 def on_mud_new_session(mud_name: Union[str, List[str]], module=None):
     def on_mud_new_session_decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_mud_event(
             mud_name, EventType.NewSession, module=module or handler.__module__
@@ -166,7 +166,7 @@ def on_mud_new_session(mud_name: Union[str, List[str]], module=None):
 
 def on_mud_new_session_or_reload(mud_name: Union[str, List[str]], module=None):
     def on_mud_new_session_or_reload_decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_mud_event(
             mud_name,
@@ -183,7 +183,7 @@ def on_mud_new_session_or_reload(mud_name: Union[str, List[str]], module=None):
 
 def on_mud_connected(mud_name: Union[str, List[str]], module=None):
     def on_mud_connected_decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_mud_event(
             mud_name, EventType.Connection, module=module or handler.__module__
@@ -199,7 +199,7 @@ def on_mud_connected(mud_name: Union[str, List[str]], module=None):
 
 def on_mud_disconnected(mud_name: Union[str, List[str]], module=None):
     def on_mud_disconnected_decorator(handler: EventHandler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         @on_mud_event(
             mud_name, EventType.Connection, module=module or handler.__module__
@@ -228,7 +228,7 @@ def alias(
         if pattern.strip() == "" or name.strip() == "":
             raise ValueError("Pattern and name must be non-empty")
 
-        ensure_async(handler)
+        __ensure_async(handler)
 
         alias_config = AliasConfig(pattern, name)
         alias_config.expansion = expansion
@@ -282,7 +282,7 @@ def trigger(
         if pattern.strip() == "" or name.strip() == "":
             raise ValueError("pattern and name must be non-empty")
 
-        ensure_async(handler)
+        __ensure_async(handler)
 
         trigger_config = TriggerConfig(pattern, name)
         trigger_config.gag = gag
@@ -394,7 +394,7 @@ def timer(
         raise ValueError("The total duration must be greater than zero.")
 
     def timer_decorator(handler):
-        ensure_async(handler)
+        __ensure_async(handler)
 
         timer_config = TimerConfig(name, total_delay_ms, handler)
         if max_ticks:

--- a/mudpuppy/python/telnet_charset.py
+++ b/mudpuppy/python/telnet_charset.py
@@ -18,14 +18,14 @@ class TelnetCharsetHandler:
     """
 
     @staticmethod
-    def on_connect(session: SessionId):
+    async def on_connect(session: SessionId):
         logging.debug(
             f"charset: negotiating Telnet charset protocol for conn {session}"
         )
-        mudpuppy_core.request_enable_option(session, CHARSET_OPTION)
+        await mudpuppy_core.request_enable_option(session, CHARSET_OPTION)
 
     @staticmethod
-    def raw_receive(session: SessionId, data: bytes):
+    async def raw_receive(session: SessionId, data: bytes):
         logging.debug(f"charset: received data for conn {session}: {data}")
         if len(data) < 2 or data[0] != REQUEST:
             logging.debug(
@@ -37,26 +37,30 @@ class TelnetCharsetHandler:
         logging.debug(f"charset: server offered: {offered}")
         for offer in offered:
             if offer in ACCEPTED_ENCODINGS:
-                mudpuppy_core.send_subnegotiation(
+                await mudpuppy_core.send_subnegotiation(
                     session, CHARSET_OPTION, bytes([ACCEPTED]) + offer
                 )
                 logging.debug(f"charset: accepted server's offer - {offer}")
                 return
 
-        mudpuppy_core.send_subnegotiation(session, CHARSET_OPTION, bytes([REJECTED]))
+        await mudpuppy_core.send_subnegotiation(
+            session, CHARSET_OPTION, bytes([REJECTED])
+        )
         logging.debug("charset: rejected server's offer - none compatible")
 
 
 @on_connected()
 async def connected(event: Event):
-    TelnetCharsetHandler.on_connect(event.id)
+    assert isinstance(event, Event.Connection)
+    await TelnetCharsetHandler.on_connect(event.id)
 
 
 @on_event(EventType.Subnegotiation)
 async def telnet_subneg_receive(event: Event):
+    assert isinstance(event, Event.Subnegotiation)
     if event.option != CHARSET_OPTION:
         return
-    TelnetCharsetHandler.raw_receive(event.id, bytes(event.data))
+    await TelnetCharsetHandler.raw_receive(event.id, bytes(event.data))
 
 
 logging.debug("telnet charset module loaded")

--- a/mudpuppy/src/python.rs
+++ b/mudpuppy/src/python.rs
@@ -61,6 +61,7 @@ pub fn mudpuppy_core(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PromptMode>()?;
     m.add_class::<client::Status>()?;
     m.add_class::<net::stream::Info>()?;
+    m.add_class::<client::output::Output>()?;
     m.add_class::<client::output::Item>()?;
     m.add_class::<client::input::Input>()?;
     m.add_class::<client::input::EchoState>()?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.pyright]
 include = ["mudpuppy/python", "python-examples"]
-stubPath = "python-typings"
+stubPath = "python-stubs"
+reportMissingModuleSource = false

--- a/python-examples/custom_layout.py
+++ b/python-examples/custom_layout.py
@@ -113,7 +113,7 @@ class TestCustomLayout:
         logging.debug(f"resizing status area by {amount}")
         constraint = manager.get_constraint(self.session_id, STATUS_SECTION)
         logging.debug(f"current: {constraint}")
-        if constraint.percentage == 0:
+        if constraint.percentage is None or constraint.percentage == 0:
             return
         constraint.set_from(Constraint.with_percentage(constraint.percentage + amount))
         logging.debug(f"now: {constraint}")
@@ -131,7 +131,7 @@ class TestCustomLayout:
         logging.debug(f"resizing channel area by {amount}")
         constraint = manager.get_constraint(self.session_id, CHANNEL_CAPTURE_SECTION)
         logging.debug(f"current: {constraint}")
-        if constraint.percentage == 0:
+        if constraint.percentage is None or constraint.percentage == 0:
             return
         constraint.set_from(Constraint.with_percentage(constraint.percentage + amount))
         logging.debug(f"now: {constraint}")
@@ -153,6 +153,8 @@ async def layout_init(session: SessionInfo, layout_manager: LayoutManager):
 @on_event(EventType.KeyPress)
 async def on_key(event: Event):
     import json
+
+    assert isinstance(event, Event.KeyPress)
 
     key_data = json.loads(event.json)
     layout = layouts.get(event.id)

--- a/python-examples/gmcp_channels.py
+++ b/python-examples/gmcp_channels.py
@@ -86,6 +86,7 @@ class ChannelLogger:
 
 @on_event(EventType.GmcpEnabled)
 async def gmcp_ready(event: Event):
+    assert isinstance(event, Event.GmcpEnabled)
     logging.debug(f"telling session {event.id} that we support gmcp Comm.Channel")
     await mudpuppy_core.gmcp_register(event.id, "Comm.Channel")
 
@@ -100,7 +101,11 @@ async def channel_text(session_id: SessionId, data: Any):
 
 @on_event(EventType.Python)
 async def py_event(event: Event):
+    assert isinstance(event, Event.Python)
     if event.custom_type != CUSTOM_LAYOUT_READY:
+        return
+
+    if event.id is None:
         return
 
     if loggers.get(event.id) is None:

--- a/python-examples/gmcp_status.py
+++ b/python-examples/gmcp_status.py
@@ -82,6 +82,7 @@ class StatusArea:
 
 @on_event(EventType.GmcpEnabled)
 async def gmcp_enabled(event: Event):
+    assert isinstance(event, Event.GmcpEnabled)
     logging.debug(f"telling {event.id} that we support gmcp Char")
     await mudpuppy_core.gmcp_register(event.id, "Char")
 
@@ -103,6 +104,11 @@ async def gmcp_status(session_id: SessionId, data: Any):
 
 @on_event(EventType.Python)
 async def py_event(event: Event):
+    assert isinstance(event, Event.Python)
+
+    if event.id is None:
+        return
+
     if event.custom_type == CUSTOM_LAYOUT_READY:
         status_area(event.id)._layout_ready()
 

--- a/python-stubs/commands.pyi
+++ b/python-stubs/commands.pyi
@@ -1,0 +1,92 @@
+"""
+The `commands` module offers functions and types for adding new `Command` instances
+to mudpuppy. Typically these are called "slash commands" since the default command
+prefix is a `/` character.
+
+`Command`s are an alternative to `mudpuppy_core.Alias` instances and are helpful if you
+want to do more complex argument parsing.
+"""
+
+# Defined explicitly to control rendered order in docs.
+__all__ = ["CommandCallable", "Command", "add_command", "all_commands"]
+
+import argparse
+import mudpuppy_core
+from typing import Callable, Awaitable, Optional
+
+type CommandCallable = Callable[
+    [mudpuppy_core.SessionId, argparse.Namespace], Awaitable[None]
+]
+"""
+An async function that is called when input sent to a MUD matches the command prefix
+and name of a command. Typically you will assign a `CommandCallable` to the `handler`
+property of a `Command`.
+
+The handler is called with:
+
+* the `mudpuppy_core.SessionId` of the session that received the input.
+* an [`argparse.Namespace`](https://docs.python.org/3/library/argparse.html#argparse.Namespace)
+  with parsed arguments.
+
+"""
+
+class Command:
+    """
+    An instance of a Mudpuppy "slash command".
+
+    See `add_command()`.
+    """
+
+    parser: argparse.ArgumentParser
+    """
+    An `argparse.ArgumentParser` that is used to parse arguments for this command.
+
+    It is created with `exit_on_error=False` and `add_help=False` to allow for custom
+    error handling and help display.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        session: mudpuppy_core.SessionId,
+        handler: CommandCallable,
+        description: Optional[str] = None,
+        aliases: Optional[list[str]] = None,
+    ):
+        """
+        Create an instance of a `Command` that is run for `/$NAME`.
+
+        * `name` - The name of the command. This is what the user will type to trigger
+          the command. E.g. `/$NAME`
+        * `session` - The session ID that the command should be
+           associated with using `add_command()`.`
+        * `handler` - a `CommandCallable` to invoke when the command is run.
+        * `description` - An optional description of the command that can be
+          shown in a command list.
+        * `aliases` - An optional list of other names the command should
+           respond to in addition to `name`.
+        """
+        ...
+
+    def display_help(self, sesh_id: mudpuppy_core.SessionId):
+        """
+        Called when the user requests help for this command.
+        """
+
+    @staticmethod
+    def on_error(message):
+        """Called by the arg parser when an error occurs"""
+        ...
+
+def add_command(sesh_id: mudpuppy_core.SessionId, command: Command):
+    """
+    Register the given `Command` as usable by the given `mudpuppy_core.SessionId`.
+    """
+    ...
+
+def all_commands(sesh_id: mudpuppy_core.SessionId) -> list[Command]:
+    """
+    Returns a list of all `Command`s that have been registered for the given `mudpuppy_core.SessionId`
+    with `add_command()`.
+    """
+    ...

--- a/python-stubs/layout.pyi
+++ b/python-stubs/layout.pyi
@@ -1,0 +1,168 @@
+"""
+The `layout` module offers functions and types for manipulating the Mudpuppy
+user interface.
+"""
+
+# Defined explicitly to control rendered order in docs.
+__all__ = ["manager", "LayoutHandler", "LayoutManager"]
+
+from typing import Callable, Awaitable, Optional
+import mudpuppy_core
+
+type LayoutHandler = Callable[
+    [mudpuppy_core.SessionInfo, LayoutManager], Awaitable[None]
+]
+"""
+An `async` function that is called when a new session is created and its layout
+must be initialized.
+
+The handler is called with:
+
+* the `mudpuppy_core.SessionInfo` of the session that received the input.
+* a `LayoutManager` to use to manipulate the session's layout.
+"""
+
+class LayoutManager:
+    """
+    A manager for customizing the TUI layout for a session.
+
+    You can register `LayoutHandler` callbacks to be invoked when layout customization
+    is required. They will be provided a `LayoutManager` argument to customize the layout.
+    """
+
+    def add_callback(self, callback: LayoutHandler):
+        """
+        Register a `LayoutHandler` to be invoked for `mudpuppy_core.EventType.NewSession`
+        and `mudpuppy_core.EventType.ResumeSession` events.
+
+        Crucially, unlike global `mudpuppy.on_new_session` or `mudpuppy.on_new_session_or_reload`
+        event handlers the `LayoutManager` handlers are invoked in the order they are added.
+
+        This makes it possible to predictable order layout customizations from multiple
+        sources by controlling the order `add_callback()` is used.
+        """
+        ...
+
+    def remove_callback(self, callback: LayoutHandler):
+        """
+        Remove a previously `LayoutHandler` callback previously registered with `add_callback()`
+        """
+        ...
+
+    def get_constraint(
+        self, sesh_id: mudpuppy_core.SessionId, section_name: str
+    ) -> mudpuppy_core.Constraint:
+        """
+        Return the `mudpuppy_core.Constraint` for the given section name in the layout for the session,
+        or raise an exception if the section name doesn't exist.
+
+        The returned `mudpuppy_core.Constraint` is mutable and can be updated by the caller.
+        """
+        ...
+
+    def hide_section(self, sesh_id: mudpuppy_core.SessionId, section_name: str):
+        """
+        Hide the section with the given name in the layout for the session, or raise an exception if the
+        section name doesn't exist.
+
+        This will remove the section from the layout until `show_section()` is invoked.
+        Internally the sections' `mudpuppy_core.Constraint` will be replaced with a
+        `mudpuppy_core.Constraint` with a `max` of `0`.
+        """
+        ...
+
+    def show_section(
+        self,
+        sesh_id: mudpuppy_core.SessionId,
+        section_name: str,
+        constraint: mudpuppy_core.Constraint,
+    ):
+        """
+        Show the section with the given name in the layout for the session, or raise an exception if the
+        section name doesn't exist.
+
+        The section's constraint will be restored to the provided `mudpuppy_core.Constraint`.
+        """
+        ...
+
+    async def extend_section(
+        self,
+        sesh_id: mudpuppy_core.SessionId,
+        *,
+        section_name: str,
+        new_section_name: str,
+        constraint: mudpuppy_core.Constraint,
+        direction: mudpuppy_core.Direction = mudpuppy_core.Direction.Vertical,
+        margin: int = 0,
+        buffer_config: Optional[mudpuppy_core.BufferConfig] = None,
+    ) -> Optional[mudpuppy_core.BufferId]:
+        """
+        Extend the `section_name` section in the `direction` specified by adding a
+        `new_section_name`, with size described by `constraint`. Pre-existing subsections
+        of `section_name` are not resized. See `split_section()` if you want to subdivide
+        an existing section by resizing the existing content.
+
+        An optional `margin` can be specified to separate it from the pre-existing
+        sections.
+
+        If `buffer_config` is provided, a new `mudpuppy_core.ExtraBuffer` will be created
+        with the provided `mudpuppy_core.BufferConfig` and assigned to the `new_section_name`
+        by setting `mudpuppy_core.BufferConfig.layout_name` to `new_section_name`.
+        The created `mudpuppy_core.BufferId` is returned to the caller.
+        """
+        ...
+
+    async def split_section(
+        self,
+        sesh_id: mudpuppy_core.SessionId,
+        *,
+        section_name: str,
+        constraint: mudpuppy_core.Constraint,
+        old_section_first: bool = True,
+        new_section_name: str,
+        new_constraint: mudpuppy_core.Constraint,
+        direction: mudpuppy_core.Direction = mudpuppy_core.Direction.Vertical,
+        margin: int = 0,
+        buffer_config: Optional[mudpuppy_core.BufferConfig] = None,
+    ) -> Optional[mudpuppy_core.BufferId]:
+        """
+        Split the existing `section_name` section in the `direction` specified.
+        A section containing both the pre-existing and new sections named
+        `f"{section_name}_{new_section_name}"` will then hold two sections:
+        `section_name` and `new_section_name` (when `old_section_first` is `True`), or
+        `new_section_name` and `section_name` (when `old_section_first` is `False`). See
+        `extend_section()` if you want to add a new section alongside an existing section.
+         without subdividing existing sections.
+
+        The direction of the section holding the two subsections is determined by `direction`.
+        An optional `margin` can be specified to separate the sections from each other.
+
+        The pre-existing section will be moved to a new subsection, maintaining the
+        name `section_name`. Its size will be determined by `constraint`.
+
+        A new section will be added alongside it with the name `new_section_name`. Its
+        size will be determined by `new_constraint`.
+
+        If `buffer_config` is provided, a new `mudpuppy_core.ExtraBuffer` will be created
+        with the provided `mudpuppy_core.BufferConfig` and assigned to the `new_section_name`
+        by setting `mudpuppy_core.BufferConfig.layout_name` to `new_section_name`.
+        The created `mudpuppy_core.BufferId` is returned to the caller.
+        """
+        ...
+
+manager: LayoutManager
+"""
+A global `LayoutManager` to use for registering custom `LayoutHandler` callbacks.
+
+Typically you will `import` this `LayoutManager` instance to register your callbacks.
+
+```python
+from layout import LayoutManager, manager
+import mudpuppy_core
+
+async def layout_init(session: mudpuppy_core.SessionInfo, layout_manager: LayoutManager):
+    ...
+
+manager.add_callback(layout_init)
+```
+"""

--- a/python-stubs/mudpuppy.pyi
+++ b/python-stubs/mudpuppy.pyi
@@ -1,0 +1,593 @@
+"""
+The `mudpuppy` module offers helpful decorators built on top of `mudpuppy_core`.
+
+These decorators can be used to set up handlers for events, GMCP messages, and to create
+triggers, aliases and timers automatically at session creation time.
+
+In most cases each global decorator has a variant that allows you to accomplish the
+same task, but for one or more specific `mudpuppy_core.Mud` names. For example,
+`on_event()` and `on_mud_event()`, or `on_connected()` and `on_mud_connected()`.
+"""
+
+# Defined explicitly to control rendered order in docs.
+__all__ = [
+    "on_event",
+    "on_mud_event",
+    "on_new_session",
+    "on_mud_new_session",
+    "on_new_session_or_reload",
+    "on_mud_new_session_or_reload",
+    "on_connected",
+    "on_mud_connected",
+    "on_disconnected",
+    "on_mud_disconnected",
+    "GmcpHandler",
+    "on_gmcp",
+    "alias",
+    "trigger",
+    "highlight",
+    "TimerCallable",
+    "timer",
+    "unload_handlers",
+]
+
+from typing import Callable, Awaitable, Union, Optional, Any
+import mudpuppy_core
+
+type GmcpHandler = Callable[[mudpuppy_core.SessionId, Any], Awaitable[None]]
+"""
+An async function that receives a `mudpuppy_core.SessionId` and GMCP data as its arguments.
+
+Example:
+```python
+async def my_gmcp_handler(session_id: mudpuppy_core.SessionId, data: Any):
+    print(f"my_gmcp_handler session {session_id} got GMCP data {data}")
+```
+"""
+
+def on_event(
+    event_type: Union[mudpuppy_core.EventType, list[mudpuppy_core.EventType]],
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    Decorator to register an async `mudpuppy_core.EventHandler` function as an event handler
+    for one or more event types.
+
+    The decorated function will be called with a `mudpuppy_core.Event` object when the
+    specified `mudpuppy_core.EventType`'s are received.
+
+    The decorated function **must** be async or an error will be produced by
+    the decorator.
+
+    If `module` is `None`, then `EventHandler.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    If you want to register an event handler only for a specific set of MUDs, use
+    `on_mud_event()` instead. If you require more control over the event handler
+    registration process you may prefer to manually use `mudpuppy_core.event_handlers`.
+
+    Example:
+    ```python
+    @on_event(mudpuppy_core.EventType.Subnegotiation)
+    async def telnet_subneg_receive(event: mudpuppy_core.Event):
+        assert(instanceof(event, mudpuppy_core.Event.Subnegotiation))
+        if event.option != 42:
+            return
+        print(f"telnet CHARSET subneg. for session {event.id}: {event.data.hex()}")
+    ````
+    """
+    ...
+
+def on_mud_event(
+    mud_name: Union[str, list[str]],
+    event_type: Union[mudpuppy_core.EventType, list[mudpuppy_core.EventType]],
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    Equivalent to `on_event()` but will only be invoked when the event
+    occurs for a session with `mudpuppy_core.SessionInfo.mud_name` equal to one
+    of the specified `mud_name`'s.
+
+    Example:
+    ```python
+    @on_mud_event(["Test (TLS)", "Test (Telnet)"], mudpuppy_core.EventType.Prompt)
+    async def prompt_handler(event: mudpuppy_core.Event):
+        assert(instanceof(event, mudpuppy_core.Event.Prompt))
+        print(f"Test MUD received prompt: {str(event.prompt)}")
+    ```
+    """
+    ...
+
+def on_gmcp(
+    package: str, module: Optional[str] = None
+) -> Callable[[GmcpHandler], GmcpHandler]:
+    """
+    Decorator to register a `GmcpHandler` as a handler for a specific GMCP package.
+    You will typically need to register intent for that GMCP package using
+    `mudpuppy_core.MudpuppyCore.gmcp_register()` after checking GMCP has been negotiated with
+    `mudpuppy_core.MudpuppyCore.gmcp_enabled()`, or in response to a
+    `mudpuppy_core.EventType.GmcpEnabled`
+    event.
+
+    The decorated function will be called with the `mudpuppy_core.SessionId` and the
+    GMCP message data whenever a `mudpuppy_core.EventType.GmcpMessage` event for the
+    specified package is received.
+
+    If `module` is `None`, then `GmcpHandler.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    Example:
+    ```python
+    # Make sure the "Char" package is registered
+    @on_event(mudpuppy_core.EventType.GmcpEnabled):
+    async def gmcp_ready(event: mudpuppy_core.Event):
+        await mudpuppy_core.gmcp_register(event.id, "Char")
+
+    # Handle the "Char.Vitals" GMCP message
+    @on_gmcp("Char.Vitals")
+    async def gmcp_vitals(session_id: mudpuppy_core.SessionId, data: Any):
+        hp = data.get("hp", 0)
+        printf(f"gmcp_vitals: session {session_id} character has {hp} hp")
+    ```
+    """
+    ...
+
+def on_new_session(
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    Decorator to register an async `mudpuppy_core.EventHandler` function as a handler for the
+    `mudpuppy_core.EventType.NewSession` event.
+
+    The decorated function will be called with a `mudpuppy_core.Event.NewSession`
+    object when a new session is created.
+
+    The decorated function **must** be async or an error will be produced by
+    the decorator.
+
+    If `module` is `None`, then `EventHandler.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    Example:
+    ```python
+    @on_new_session()
+    async def new_session_handler(event: mudpuppy_core.Event):
+        assert(instanceof(event, mudpuppy_core.Event.NewSession))
+        print(f"new {event.mud} session created: {event.id}")
+    ```
+    """
+    ...
+
+def on_mud_new_session(
+    mud_name: Union[str, list[str]],
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    The same as `on_new_session()` but will only be invoked when the event
+    occurs for a session with `mudpuppy_core.SessionInfo.mud_name` equal to one
+    of the specified `mud_name`'s.
+
+    Example:
+    ```python
+    @on_mud_new_session("Test (TLS)")
+    async def new_session_handler(event: mudpuppy_core.Event):
+        assert(instanceof(event, mudpuppy_core.Event.NewSession))
+        assert(event.mud.name == "Test (TLS)")
+        print(f"new {event.mud} session created: {event.id}")
+    ```
+    """
+    ...
+
+def on_new_session_or_reload(
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    Decorator to register an async `mudpuppy_core.EventHandler` function as a handler for both
+    `mudpuppy_core.EventType.NewSession` and `mudpuppy_core.EventType.ResumeSession`
+    events.
+
+    The decorated function will be called with a `mudpuppy_core.Event.NewSession`
+    or `mudpuppy_core.Event.ResumeSession` object when a new session is created,
+    or when the module is reloaded for existing sessions.
+
+    The decorated function **must** be async or an error will be produced by
+    the decorator.
+
+    If `module` is `None`, then `EventHandler.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    Example:
+    ```python
+    @on_new_session_or_reload()
+    async def new_or_resumed_handler(event: mudpuppy_core.Event):
+        if instanceof(event, mudpuppy_core.Event.ResumeSession):
+            print(f"resuming session: {event.id}")
+        elif instanceof(event, mudpuppy_core.Event.NewSession):
+            print(f"new {event.mud} session created: {event.id}")
+    ```
+    """
+    ...
+
+def on_mud_new_session_or_reload(
+    mud_name: Union[str, list[str]],
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    The same as `on_new_session_or_reload()` but will only be invoked when the event
+    occurs for a session with `mudpuppy_core.SessionInfo.mud_name` equal to one
+    of the specified `mud_name`'s.
+    """
+    ...
+
+def on_connected(
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    Decorator to register an async `mudpuppy_core.EventHandler` function as a handler for the
+    `mudpuppy_core.EventType.Connection` events that indicate the new connection
+     `mudpuppy_core.Status` is `mudpuppy_core.Status.Connected`.
+
+    The decorated function will be called with a `mudpuppy_core.Event.Connection`
+    object when a session is connected.
+
+    The decorated function **must** be async or an error will be produced by
+    the decorator.
+
+    If `module` is `None`, then `EventHandler.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    Example:
+    ```python
+    @on_connected()
+    async def connected_handler(event: mudpuppy_core.Event):
+        assert(instanceof(event, mudpuppy_core.Event.Connection))
+        assert(instanceof(event.status, mudpuppy_core.Status.Connected))
+        print(f"session {event.id} connected: {event.status}")
+    ```
+    """
+    ...
+
+def on_mud_connected(
+    mud_name: Union[str, list[str]],
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    The same as `on_connected()` but will only be invoked when the event
+    occurs for a session with `mudpuppy_core.SessionInfo.mud_name` equal to one
+    of the specified `mud_name`'s.
+    """
+    ...
+
+def on_disconnected(
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    Decorator to register an async `mudpuppy_core.EventHandler` function as a handler for the
+    `mudpuppy_core.EventType.Connection` events that indicate the new connection
+     `mudpuppy_core.Status` is `mudpuppy_core.Status.Disconnected`.
+
+    The decorated function will be called with a `mudpuppy_core.Event.Connection`
+    object when a session is disconnected.
+
+    The decorated function **must** be async or an error will be produced by
+    the decorator.
+
+    If `module` is `None`, then `EventHandler.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    Example:
+    ```python
+    @on_disconnected()
+    async def disconnected_handler(event: mudpuppy_core.Event):
+        assert(instanceof(event, mudpuppy_core.Event.Connection))
+        assert(instanceof(event.status, mudpuppy_core.Status.Disconnected))
+        print(f"session {event.id} disconnected")
+    ```
+    """
+    ...
+
+def on_mud_disconnected(
+    mud_name: Union[str, list[str]],
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.EventHandler], mudpuppy_core.EventHandler]:
+    """
+    The same as `on_disconnected()` but will only be invoked when the event
+    occurs for a session with `mudpuppy_core.SessionInfo.mud_name` equal to one
+    of the specified `mud_name`'s.
+    """
+    ...
+
+def alias(
+    *,
+    pattern: str,
+    name: str,
+    expansion: Optional[str] = None,
+    mud_name: Optional[Union[str | list[str]]] = None,
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.AliasCallable], mudpuppy_core.AliasCallable]:
+    """
+    Decorator to register an async `mudpuppy_core.AliasCallable` function as an alias handler for
+    a specific pattern. A `mudpuppy_core.Alias` will be automatically created for the decorated
+    function when `mudpuppy_core.EventType.NewSession` and
+    `mudpuppy_core.EventType.ResumeSession` events occur.
+
+    When input is provided matching the compiled regexp `pattern` the decorated function
+    will be invoked with the `mudpuppy_core.SessionId` of the session that received the
+    input, the `mudpuppy_core.AliasId` of the `mudpuppy_core.Alias` that matched, the
+    input line that matched, and a list of captured groups from the pattern (if any).
+
+    The `pattern` must be a valid regular expression. You can read more about the allowed
+    syntax [in the `regexp` crate docs](https://docs.rs/regex/latest/regex/#syntax). Note
+    that for performance reasons the Python `regex` module is not used - the pattern
+    is used to create a Rust regular expression object. By using group syntax you will
+    receive the matched groups as a separate list argument to the decorated function.
+
+    An optional `expansion` string may be provided. When the alias matches the
+    `expansion` will be sent to the MUD as input. This is a convenient shorthand
+    for writing `await mudpuppy_core.MudpuppyCore.send_line(session_id, expansion)`
+    in the body of your `mudpuppy_core.AliasCallable`.
+
+    If a `mud_name`, or list of `mud_name`'s are provided then the alias will only be
+    registered for sessions with the specified `mud_name`'s.
+
+    If `module` is `None`, then `AliasCallable.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    If you want more control over the alias creation process (for example, because
+    you want to add an alias sometime after session creation or wish to store the
+    `mudpuppy_core.AliasId` of the created alias) you should prefer to instantiate
+    your own `mudpuppy_core.AliasConfig` to use with
+    `mudpuppy_core.MudpuppyCore.new_alias()`.
+
+    Example:
+    ```python
+    import asyncio
+    from mudpuppy_core import mudpuppy_core, SessionId, AliasId
+
+    @alias(mud_name="Test (TLS)", pattern="^kill (.*)$", name="Start combat alias")
+    async def start_combat(session_id: SessionId, _alias_id: AliasId, _line: str, groups: list[str]):
+        assert(len(groups) == 1)
+        target = groups[0]
+        await mudpuppy_core.send(session_id, f"backstab {target}")
+        await asyncio.sleep(10)
+        await mudpuppy_core.send(session_id, f"steal from {target}")
+    ```
+    """
+
+def trigger(
+    *,
+    pattern: str,
+    name: str,
+    gag: bool = False,
+    strip_ansi: bool = True,
+    prompt: bool = False,
+    expansion: Optional[str] = None,
+    mud_name: Optional[Union[str, list[str]]] = None,
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.TriggerCallable], mudpuppy_core.TriggerCallable]:
+    """
+    Decorator to register an async `mudpuppy_core.TriggerCallable` function as a trigger handler for
+    a specific pattern. A `mudpuppy_core.Trigger` will be automatically created for the decorated
+    function when `mudpuppy_core.EventType.NewSession` and
+    `mudpuppy_core.EventType.ResumeSession` events occur.
+
+    When output is received matching the compiled regexp `pattern` the decorated function
+    will be invoked with the `mudpuppy_core.SessionId` of the session that received the
+    output, the `mudpuppy_core.TriggerId` of the `mudpuppy_core.Trigger` that matched, the
+    output line that matched, and a list of captured groups from the pattern (if any).
+
+    The `pattern` must be a valid regular expression. You can read more about the allowed
+    syntax [in the `regexp` crate docs](https://docs.rs/regex/latest/regex/#syntax). Note
+    that for performance reasons the Python `regex` module is not used - the pattern
+    is used to create a Rust regular expression object. By using group syntax you will
+    receive the matched groups as a separate list argument to the decorated function.
+
+    If `gag` is `True`, then the line that matched the trigger's `pattern` will be
+    gagged and **not displayed** in the MUD output area. This is useful for suppressing
+    text from the MUD server you don't want to see (e.g. because it's spammy, or because
+    you're post-processing it into something easier to understand that you'll output
+    manually).
+
+    If `strip_ansi` is `True` (default), then the line that matched the trigger's `pattern`
+    will have ANSI escape codes stripped before being passed to the decorated function.
+    You typically want `strip_ansi` enabled so that your `pattern` regexp doesn't have to
+    match the ANSI colour codes that may be decorating output. If you **do** want to write
+    a pattern that only matches text in a specific colour you can set `strip_ansi=False`.
+
+    If `prompt` is `True`, then the trigger will only match if the line was detected as
+    a prompt. The `pattern` must also match. Writing triggers with `prompt=True` is an
+    alternative to registering a `mudpuppy_core.EventType.Prompt` event handlers and can
+    be useful if you want to gag a prompt by setting both `prompt=True` and `gag=True`
+    and writing a matching `pattern`.
+
+    An optional `expansion` string may be provided. When the trigger matches the
+    `expansion` will be sent to the MUD as input.  This is a convenient shorthand
+    for writing `await mudpuppy_core.MudpuppyCore.send_line(session_id, expansion)`
+    in the body of your `mudpuppy_core.TriggerCallable`.
+
+    If a `mud_name`, or list of `mud_name`'s are provided then the trigger will only be
+    registered for sessions with the specified `mud_name`'s.
+
+    If `module` is `None`, then `TriggerCallable.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    If you want more control over the trigger creation process (for example, because
+    you want to add a trigger sometime after session creation or wish to store the
+    `mudpuppy_core.TriggerId` of the created trigger) you should prefer to instantiate
+    your own `mudpuppy_core.TriggerConfig` to use with
+    `mudpuppy_core.MudpuppyCore.new_trigger()`.
+
+    Example:
+    ```python
+    from mudpuppy_core import mudpuppy_core, SessionId, TriggerId
+    from mudpuppy import trigger
+
+    @trigger(name="Auto-keep", pattern="^You wear (.*)$")
+    async def auto_keep(
+        session_id: SessionId, _trigger_id: TriggerId, _line: str, groups: list[str]
+    ):
+        await mudpuppy_core.send_line(session_id, f"keep {groups[0]}")
+    ```
+    """
+    ...
+
+def highlight(
+    *,
+    pattern: str,
+    name: str,
+    strip_ansi: bool = True,
+    mud_name: Optional[Union[str, list[str]]] = None,
+    module: Optional[str] = None,
+) -> Callable[[mudpuppy_core.HighlightCallable], mudpuppy_core.HighlightCallable]:
+    """
+    Decorator to register a **non-async** `mudpuppy_core.HighlightCallable` function as a highlight
+    handler for a specific pattern. A `mudpuppy_core.Trigger` for the highlight
+    will be automatically created for the decorated function when
+    `mudpuppy_core.EventType.NewSession` and `mudpuppy_core.EventType.ResumeSession`
+    events occur.
+
+    When output is received matching the compiled regexp `pattern` the decorated function
+    will be invoked with the `mudpuppy_core.MudLine` that matched the `pattern`,
+    and a list of captured groups from the pattern (if any).
+
+    The `pattern` must be a valid regular expression. You can read more about the allowed
+    syntax [in the `regexp` crate docs](https://docs.rs/regex/latest/regex/#syntax). Note
+    that for performance reasons the Python `regex` module is not used - the pattern
+    is used to create a Rust regular expression object. By using group syntax you will
+    receive the matched groups as a separate list argument to the decorated function.
+
+    If `strip_ansi` is `True` (default), then the line that matched the highlight
+    trigger's `pattern` will have ANSI escape codes stripped before being passed to the
+    decorated function. You typically want `strip_ansi` enabled so that your `pattern`
+    regexp doesn't have to match the ANSI colour codes that may be decorating output.
+    If you **do** want to write a pattern that only matches text in a specific colour
+    you can set `strip_ansi=False`.
+
+    If a `mud_name`, or list of `mud_name`'s are provided then the trigger will only be
+    registered for sessions with the specified `mud_name`'s.
+
+    If `module` is `None`, then `HighlightCallable.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    If you want more control over the trigger creation process (for example, because
+    you want to add a trigger sometime after session creation or wish to store the
+    `mudpuppy_core.TriggerId` of the created trigger) you should prefer to instantiate
+    your own `mudpuppy_core.TriggerConfig` to use with
+    `mudpuppy_core.MudpuppyCore.add_trigger()`.
+
+    Example:
+    ```python
+    from mudpuppy import highlight
+
+    @highlight(name="Solaris highlight", pattern=r"^(\\d+) solaris$")
+    def solaris_highlight(line: mudpuppy_core.MudLine, groups: list[str]):
+        assert len(groups) == 1
+        # Highlight the total in bold
+        hilight = line.__str__().replace(
+            groups[0], cformat(f"<bold><yellow>{groups[0]}<reset><yellow>")
+        )
+        # And then overall line in yellow
+        hilight = cformat(f"<yellow>{hilight}<reset>")
+        line.set(hilight)
+        return line
+    ```
+    """
+    ...
+
+type TimerCallable = Callable[
+    [mudpuppy_core.TimerId, Optional[mudpuppy_core.SessionId]], Awaitable[None]
+]
+"""
+An async function that is called when a timer expires. See `mudpuppy.timer()` for the
+associated `@timer()` decorator.
+
+The handler is called with:
+
+* the `mudpuppy_core.TimerId` of the timer that expired.
+* either `None`, or `mudpuppy_core.SessionId` if the `mudpuppy_core.Timer` was created
+  for a specific `mudpuppy_core.SessionId`.
+
+Example:
+```python
+from mudpuppy_core import mudpuppy_core
+
+async def my_timer_handler(timer_id: mudpuppy_core.TimerId, sesh: Optional[mudpuppy_core.SessionId]):
+    timer: mudpuppy_core.Timer = await mudpuppy_core.get_timer(sesh, timer_id)
+    print(f"trigger {timer.config.name} has fired")
+    if randint(1, 3) == 1:
+        print(f"stopping timer {timer_id}")
+        await mudpuppy_core.stop_timer(sesh, timer_id)
+```
+"""
+
+def timer(
+    *,
+    name: str,
+    milliseconds: int = 0,
+    seconds: int = 0,
+    minutes: int = 0,
+    hours: int = 0,
+    max_ticks: Optional[int] = None,
+    mud_name: Optional[Union[str, list[str]]] = None,
+    module: Optional[str] = None,
+) -> Callable[[TimerCallable], TimerCallable]:
+    """
+    Decorator to register an async `TimerCallable` function as a timer handler run every
+    specified duration. A `mudpuppy_core.Timer` will be automatically created for the decorated
+    function when `mudpuppy_core.EventType.NewSession` and
+    `mudpuppy_core.EventType.ResumeSession` events occur.
+
+    A duration is calculated based on the `milliseconds`, `seconds`, `minutes`, and `hours`
+    arguments. After the duration has expired the `TimerCallable` is invoked. This will
+    happen over and over until the timer is stopped with `mudpuppy_core.MudpuppyCore.stop_timer()`
+    or until the optional `max_ticks` value is reached.
+
+    If a `mud_name`, or list of `mud_name`'s are provided then the timer will only be
+    registered for sessions with the specified `mud_name`'s.
+
+    If `module` is `None`, then `TimerCallable.__module__` will be used. The module
+    name is used only for unregistering handlers when the module is to be reloaded.
+    See `unload_handlers()` for more information.
+
+    If you want more control over the timer creation process (for example, because
+    you want to add a timer sometime after session creation or wish to store the
+    `mudpuppy_core.TimerId` of the created timer) you should prefer to instantiate
+    your own `mudpuppy_core.TimerConfig` to use with
+    `mudpuppy_core.MudpuppyCore.new_timer()`.
+
+    Example:
+    ```python
+    from mudpuppy_core import mudpuppy_core, SessionId, TimerId
+    from mudpuppy import timer
+
+    @timer(name="Auto-save", minutes=10, seconds=30)
+    async def auto_save(
+        _timer_id: TimerId, session_id: Optional[SessionId]
+    ):
+        assert(session_id is not None)
+        await mudpuppy_core.send_line(session_id, "save")
+    ```
+    """
+    ...
+
+def unload_handlers(module: str):
+    """
+    Unregister all event handlers, GMCP handlers, triggers, aliases, and timers
+    registered by the specified module.
+
+    This is useful to call ahead of a module reload to ensure that no handlers
+    are left registered for the old module.
+
+    The `module` name should be the same as the `module` argument passed to the
+    various handler decorators at the time of registration.
+    """
+    ...

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -2220,10 +2220,22 @@ print(f"running {version}")
 
 event_handlers: EventHandlers
 """
-A `EventHandlers` instance for registering event handlers with the client.
+An `EventHandlers` instance for registering event handlers with the client.
 
 It is automatically set up when Mudpuppy is running and has loaded your scripts.
 
 You will typically want to use the `mudpuppy` decorators instead of directly
 interacting with the `EventHandlers`.
+
+To manually register an event handler, you can use `EventHandlers.add_handler()`:
+
+```python
+from mudpuppy_core import mudpuppy_core, event_handlers, Event, EventType
+
+async def on_gmcp_enabled(event: Event):
+    print(f"GMCP enabled for session {event.id}")
+    await mudpuppy_core.gmcp_register(event.id, "Char")
+
+event_handlers.add_handler(EventType.GmcpEnabled, on_gmcp_enabled, __name__)
+```
 """


### PR DESCRIPTION
* Ratatui vendored reflow code update
* ruff-format pre-commit hook
* pyright pre-commit hook
* a lot more stubs/API documentation

As of this point all of the bundled .py code (`mudpuppy/python/*.py` and `python-examples/*.py`) passes static typechecking with `pyright` and the `.pyi` stubs.