### PR TITLE
remove pyo3-async-runtimes cargo patch, tidy up stub assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,8 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.21.0"
-source = "git+https://github.com/PyO3/pyo3-async-runtimes.git?rev=284bd36d0426a988026f878cae22abdb179795e6#284bd36d0426a988026f878cae22abdb179795e6"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2529f0be73ffd2be0cc43c013a640796558aa12d7ca0aab5cc14f375b4733031"
 dependencies = [
  "futures",
  "once_cell",
@@ -1402,12 +1403,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.21.0"
-source = "git+https://github.com/PyO3/pyo3-async-runtimes.git?rev=284bd36d0426a988026f878cae22abdb179795e6#284bd36d0426a988026f878cae22abdb179795e6"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c26fd8e9fc19f53f0c1e00bf61471de6789f7eb263056f7f944a9cceb5823e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ human-panic = "2"
 notify = "7"
 pretty_assertions = "1"
 pyo3 = { version = "0.22", features = ["experimental-async", "py-clone"] }
-pyo3-async-runtimes = { version = "0.21", features = ["attributes", "tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.22", features = ["attributes", "tokio-runtime"] }
 pyo3-pylogger = "0.3"
 ratatui = { version = "0.29", default-features = false }
 regex = "1"
@@ -77,7 +77,3 @@ strip = true
 
 [profile.dist]
 inherits = "release"
-
-[patch.crates-io]
-# TODO(@cpu): remove once pyo3-async-runtimes cuts a 0.22 release.
-pyo3-async-runtimes  = { git = 'https://github.com/PyO3/pyo3-async-runtimes.git', rev = '284bd36d0426a988026f878cae22abdb179795e6' }

--- a/flake.nix
+++ b/flake.nix
@@ -48,13 +48,7 @@
               inherit (mudpuppyCargoToml.package) name version;
               src = ./.;
               buildAndTestSubdir = "mudpuppy";
-              cargoLock = {
-                lockFile = ./Cargo.lock;
-                outputHashes = {
-                  "pyo3-async-runtimes-0.21.0" =
-                    "sha256-+zMamQGI5xyEDc8356/fKKft+7ABS0a9EcwDa1L/mOc=";
-                };
-              };
+              cargoLock.lockFile = ./Cargo.lock;
               buildFeatures = features;
               buildInputs = runtimeDeps;
               nativeBuildInputs = buildDeps;

--- a/python-stubs/mudpuppy.pyi
+++ b/python-stubs/mudpuppy.pyi
@@ -71,7 +71,7 @@ def on_event(
     ```python
     @on_event(mudpuppy_core.EventType.Subnegotiation)
     async def telnet_subneg_receive(event: mudpuppy_core.Event):
-        assert(instanceof(event, mudpuppy_core.Event.Subnegotiation))
+        assert isinstance(event, mudpuppy_core.Event.Subnegotiation)
         if event.option != 42:
             return
         print(f"telnet CHARSET subneg. for session {event.id}: {event.data.hex()}")
@@ -93,7 +93,7 @@ def on_mud_event(
     ```python
     @on_mud_event(["Test (TLS)", "Test (Telnet)"], mudpuppy_core.EventType.Prompt)
     async def prompt_handler(event: mudpuppy_core.Event):
-        assert(instanceof(event, mudpuppy_core.Event.Prompt))
+        assert isinstance(event, mudpuppy_core.Event.Prompt)
         print(f"Test MUD received prompt: {str(event.prompt)}")
     ```
     """
@@ -155,7 +155,7 @@ def on_new_session(
     ```python
     @on_new_session()
     async def new_session_handler(event: mudpuppy_core.Event):
-        assert(instanceof(event, mudpuppy_core.Event.NewSession))
+        assert instance(event, mudpuppy_core.Event.NewSession)
         print(f"new {event.mud} session created: {event.id}")
     ```
     """
@@ -174,8 +174,8 @@ def on_mud_new_session(
     ```python
     @on_mud_new_session("Test (TLS)")
     async def new_session_handler(event: mudpuppy_core.Event):
-        assert(instanceof(event, mudpuppy_core.Event.NewSession))
-        assert(event.mud.name == "Test (TLS)")
+        assert isinstance(event, mudpuppy_core.Event.NewSession)
+        assert event.mud.name == "Test (TLS)"
         print(f"new {event.mud} session created: {event.id}")
     ```
     """
@@ -204,9 +204,9 @@ def on_new_session_or_reload(
     ```python
     @on_new_session_or_reload()
     async def new_or_resumed_handler(event: mudpuppy_core.Event):
-        if instanceof(event, mudpuppy_core.Event.ResumeSession):
+        if isinstance(event, mudpuppy_core.Event.ResumeSession):
             print(f"resuming session: {event.id}")
-        elif instanceof(event, mudpuppy_core.Event.NewSession):
+        elif isinstance(event, mudpuppy_core.Event.NewSession):
             print(f"new {event.mud} session created: {event.id}")
     ```
     """
@@ -245,8 +245,8 @@ def on_connected(
     ```python
     @on_connected()
     async def connected_handler(event: mudpuppy_core.Event):
-        assert(instanceof(event, mudpuppy_core.Event.Connection))
-        assert(instanceof(event.status, mudpuppy_core.Status.Connected))
+        assert isinstance(event, mudpuppy_core.Event.Connection)
+        assert isinstance(event.status, mudpuppy_core.Status.Connected)
         print(f"session {event.id} connected: {event.status}")
     ```
     """
@@ -285,8 +285,8 @@ def on_disconnected(
     ```python
     @on_disconnected()
     async def disconnected_handler(event: mudpuppy_core.Event):
-        assert(instanceof(event, mudpuppy_core.Event.Connection))
-        assert(instanceof(event.status, mudpuppy_core.Status.Disconnected))
+        assert isinstance(event, mudpuppy_core.Event.Connection)
+        assert isinstance(event.status, mudpuppy_core.Status.Disconnected)
         print(f"session {event.id} disconnected")
     ```
     """
@@ -353,7 +353,7 @@ def alias(
 
     @alias(mud_name="Test (TLS)", pattern="^kill (.*)$", name="Start combat alias")
     async def start_combat(session_id: SessionId, _alias_id: AliasId, _line: str, groups: list[str]):
-        assert(len(groups) == 1)
+        assert len(groups) == 1
         target = groups[0]
         await mudpuppy_core.send(session_id, f"backstab {target}")
         await asyncio.sleep(10)
@@ -573,7 +573,7 @@ def timer(
     async def auto_save(
         _timer_id: TimerId, session_id: Optional[SessionId]
     ):
-        assert(session_id is not None)
+        assert session_id is not None
         await mudpuppy_core.send_line(session_id, "save")
     ```
     """

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -407,7 +407,7 @@ from cformat import cformat
 
 # Note: **not async**!
 def example_highlight_callable(line: MudLine, groups):
-    assert(len(groups) == 1)
+    assert len(groups) == 1
     new_line = line.__str__().replace(
         groups[0], cformat(f"<bold><cyan>{groups[0]}<reset>")
     )


### PR DESCRIPTION
* `pyo3-async-runtimes` cut a [0.22 release](https://github.com/PyO3/pyo3-async-runtimes/releases/tag/v0.22.0) so we can drop the cargo patch
* I was using Python `assert` and type checking wrong in some stub example code. Tidy that up.