### PR TITLE
python: improve /py command ergonomics

### DIFF
--- a/python-stubs/commands.pyi
+++ b/python-stubs/commands.pyi
@@ -78,6 +78,13 @@ class Command:
         """Called by the arg parser when an error occurs"""
         ...
 
+    async def invoke(self, sesh_id: mudpuppy_core.SessionId, args: str):
+        """
+        Invoke the command for the provided `mudpuppy_core.SessionId` by parsing `args` with the `Command`'s
+        parser.
+        """
+        ...
+
 def add_command(sesh_id: mudpuppy_core.SessionId, command: Command):
     """
     Register the given `Command` as usable by the given `mudpuppy_core.SessionId`.


### PR DESCRIPTION
* Escape `"` and `'` automatically, so you can write `/py "foo"` instead of `/py \"foo\"`.
* Don't display `None` results.
* Automatically `await` any awaitable results.
* Use `exec()` for things that aren't an `eval()`-able expression. This allows defining functions, setting variables, importing modules, and so on.
* Persist `globals()` between `/py` calls. This means you can do things like `/py import random` and then `/py random.randint(10, 20)` or `/py foo = "hello"` followed by `/py foo`.

Lots of room for improvement left:

* importing more stuff by default?
* offering some helper fns?
* some manner of multi-line input ala `python` REPL when you `def foo(): `... and then enter each line at a time?