### PR TITLE
python: catch warnings to avoid stdout corruption

### DIFF
--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -1321,7 +1321,7 @@ class MudpuppyCore:
         For more control over output, use `MudpuppyCore.add_output()` instead.
         """
 
-    async def active_session(self) -> Optional[SessionId]:
+    async def active_session_id(self) -> Optional[SessionId]:
         """
         Returns the ID of the currently active session, or `None` if no session
         is active.


### PR DESCRIPTION
The `mudpuppy` Python module is a good place to set up a custom Python `warnings.showwarning` handler to redirect warnings to `logging` and the active session's output buffer. The default behaviour is to print the warning to stdout, but since we're drawing a TUI there it will corrupt the interface.

This is particularly important because common mistakes like forgetting to await a coroutine will provoke this warning path. We both need to avoid corrupting the UI in that case, but also surface the error to the user.

Along the way, fix the name of the `mudpuppy_core.MudpuppyCore.active_session_id()` stub.