### PR TITLE
send_lines(), command splitting support

### DIFF
--- a/mudpuppy/src/client/input.rs
+++ b/mudpuppy/src/client/input.rs
@@ -328,6 +328,15 @@ impl Display for EchoState {
     }
 }
 
+impl From<EchoState> for bool {
+    fn from(state: EchoState) -> Self {
+        match state {
+            EchoState::Enabled => true,
+            EchoState::Password => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mudpuppy/src/config.rs
+++ b/mudpuppy/src/config.rs
@@ -267,11 +267,8 @@ impl GlobalConfig {
     ///
     /// Returns an error if the MUD can't be found in the configuration by the given name.
     pub fn must_lookup_mud(&self, mud_name: &str) -> Result<Mud> {
-        self.lookup(
-            |config| config.muds.iter().find(|m| m.name == mud_name).cloned(),
-            None,
-        )
-        .ok_or(Error::Config(ConfigError::MissingMud(mud_name.to_string())))
+        self.lookup_mud(mud_name)
+            .ok_or(ConfigError::MissingMud(mud_name.to_string()).into())
     }
 }
 

--- a/mudpuppy/src/model.rs
+++ b/mudpuppy/src/model.rs
@@ -109,6 +109,10 @@ pub struct Mud {
     /// output history.
     #[serde(default = "default::splitview_margin_vertical")]
     pub splitview_margin_vertical: u16,
+
+    /// The command separator to use when sending multiple commands in a single message.
+    #[serde(default = "default::command_separator")]
+    pub command_separator: Option<String>,
 }
 
 impl Display for Mud {
@@ -587,10 +591,7 @@ impl AliasConfig {
     ///
     // TODO(XXX): Tidy, remove unwrap.
     #[must_use]
-    pub fn matches(&self, input: &Option<String>) -> (bool, Option<Vec<String>>) {
-        let Some(input) = input else {
-            return (false, None);
-        };
+    pub fn matches(&self, input: &str) -> (bool, Option<Vec<String>>) {
         match self.regex.captures(input) {
             Some(matches) => {
                 let captures = matches
@@ -781,5 +782,10 @@ mod default {
 
     pub(super) fn no_tcp_keepalive() -> bool {
         false
+    }
+
+    #[allow(clippy::unnecessary_wraps)] // Matching config field.
+    pub(super) fn command_separator() -> Option<String> {
+        Some(";;".to_string())
     }
 }

--- a/mudpuppy/src/python.rs
+++ b/mudpuppy/src/python.rs
@@ -352,6 +352,23 @@ impl PyApp {
         })
     }
 
+    fn send_lines<'py>(
+        &self,
+        py: Python<'py>,
+        id: SessionId,
+        lines: Vec<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        with_state!(self, py, |mut state| {
+            for line in lines {
+                state
+                    .client_for_id_mut(id)
+                    .ok_or(Error::from(id))?
+                    .send_line(InputLine::new(line, true, true))?;
+            }
+            Ok(())
+        })
+    }
+
     fn connect<'py>(&self, py: Python<'py>, id: SessionId) -> PyResult<Bound<'py, PyAny>> {
         with_state!(self, py, |mut state| {
             state

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -296,6 +296,11 @@ class Mud:
     Describes the TLS configuration for the MUD.
     """
 
+    command_separator: Optional[str]
+    """
+    An optional command separator to use when sending multiple commands in a single line.
+    """
+
 class MudLine:
     """
     A line received from a MUD.
@@ -1359,7 +1364,24 @@ class MudpuppyCore:
         The input will be marked as "scripted" to differentiate it from true user input
         typed at the keyboard.
 
+        [Command splitting](https://mudpuppy-rs.github.io/mudpuppy/user-guide/input.html#command-splitting) 
+        works the same as for normal user input.
+
+        Unlike true user input, aliases are **not** evaluated for `send_line()`
+        input. This also means it isn't possible to send slash
+        [command](https://mudpuppy-rs.github.io/mudpuppy/user-guide/commands.html)
+        input in this manner.
+
         Prefer using `MudpuppyCore.send_lines()` for sending multiple lines.
+
+        Example:
+
+        ```python
+        from mudpuppy_core import mudpuppy_core
+        session_id = ...
+        mudpuppy_core.send_line(session_id, "hello") # Sends 'hello'
+        mudpuppy_core.send_line(session_id, "hello;;wave") # Sends 'hello' and then 'wave'
+        ```
         """
         ...
 

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -1596,9 +1596,7 @@ class MudpuppyCore:
         """
         ...
 
-    async def get_timer(
-        self, timer_id: TimerId
-    ) -> Optional[Timer]:
+    async def get_timer(self, timer_id: TimerId) -> Optional[Timer]:
         """
         Returns the `Timer` for the given `TimerId` if it exists.
 
@@ -2600,9 +2598,7 @@ class EventHandlers:
         """
         ...
 
-    def get_handlers(
-        self, event_type: EventType
-    ) -> Optional[list[EventHandler]]:
+    def get_handlers(self, event_type: EventType) -> Optional[list[EventHandler]]:
         """
         Returns a list of handlers for the given `EventType` if any are registered.
         """

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -1358,6 +1358,19 @@ class MudpuppyCore:
 
         The input will be marked as "scripted" to differentiate it from true user input
         typed at the keyboard.
+
+        Prefer using `MudpuppyCore.send_lines()` for sending multiple lines.
+        """
+        ...
+
+    async def send_lines(self, session_id: SessionId, lines: list[str]):
+        """
+        Sends a list of lines of text to the given session as if they were input sent by the user.
+
+        The input will be marked as "scripted" to differentiate it from true user input
+        typed at the keyboard.
+
+        Prefer using `MudpuppyCore.send_line()` for sending a single line.
         """
         ...
 

--- a/user-guide/src/SUMMARY.md
+++ b/user-guide/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Command line](cli.md)
 - [Config](config.md)
+- [Input](input.md)
 - [Commands](commands.md)
 - [Logging](logging.md)
 - [Scripting](scripting/README.md)

--- a/user-guide/src/input.md
+++ b/user-guide/src/input.md
@@ -1,0 +1,34 @@
+# Input
+
+## Command splitting
+
+Often it's useful to be able to enter several commands all in one go. For this
+situation Mudpuppy supports input that's split into multiple commands based on
+a special command splitting delimiter. 
+
+By default this delimiter is `;;` but it can be adjusted by setting the
+`command_separator` field of a MUD config.
+
+### Example
+
+For example, if you typed the following input and hit enter:
+
+```
+say hello;;wave;;/status -v
+```
+
+Then Mudpuppy would send these commands to the MUD:
+
+1. `say hello`
+2. `wave`
+
+and then it would run the `/status -v` [command].
+
+If you've defined an [alias] for the pattern `^wave$` (for example) it would be
+evaluated just like if you typed `wave` without using the `;;` splitter.
+
+Remember if you've changed the `command_separator` you'll have to adjust the
+example above.
+
+[command]: commands.md
+[alias]: scripting/aliases.md


### PR DESCRIPTION
Couple small changes from last weekend I want to clear from my WIP branch:

## python: add mudpuppy_core.send_lines()

A plural version of `MudPuppyCore.send_line()` for convenience. Should have had this from the start :-P

## support multiple input splitting
The command splitter is specified in the MUD config and defaults to ';;'. Splitting is performed in two places:

* When processing human input from an enter keypress (notably, before aliases are evaluated). This allows input like 'say hi;;/py True;;say whatever" where slash commands from aliases can be used.
* When processing scripted input from `send_line()` or `send_lines()` - in this case alias expansion isn't performed (and getting that to happen is architecturally tricky...) but this is an existing limitation of those APIs.

I'm a little unhappy with the duplication & limitations uncovered by playing with this idea but it's better to make a little progress than block on perfection.