### PR TITLE
misc saturday morning fixes/updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "ratatui",
  "simdutf8",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -326,7 +326,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -629,7 +629,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -923,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
 dependencies = [
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1121,7 +1121,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "strip-ansi-escapes",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1288,7 +1288,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1330,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1357,7 +1357,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1409,7 +1409,7 @@ checksum = "22c26fd8e9fc19f53f0c1e00bf61471de6789f7eb263056f7f944a9cceb5823e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1441,7 +1441,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1454,7 +1454,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1544,7 +1544,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1841,7 +1841,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1896,7 +1896,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -1907,7 +1916,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1946,7 +1966,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2099,7 +2119,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2498,7 +2518,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "f54b3d09cbdd1f8c20650b28e7b09e338881482f4aa908a5f61a00c98fba2690"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2529f0be73ffd2be0cc43c013a640796558aa12d7ca0aab5cc14f375b4733031"
+checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
 dependencies = [
  "futures",
  "once_cell",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c26fd8e9fc19f53f0c1e00bf61471de6789f7eb263056f7f944a9cceb5823e"
+checksum = "b2df2884957d2476731f987673befac5d521dff10abb0a7cbe12015bc7702fe9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "3015cf985888fe66cfb63ce0e321c603706cd541b7aec7ddd35c281390af45d8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "6fca7cd8fd809b5ac4eefb89c1f98f7a7651d3739dfb341ca6980090f554c270"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "34e657fa5379a79151b6ff5328d9216a84f55dc93b17b08e7c3609a969b73aa0"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "295548d5ffd95fd1981d2d3cf4458831b21d60af046b729b6fd143b0ba7aee2f"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = "1"
 serde_json = "1"
 socket2 = "0.5"
 strip-ansi-escapes = "0.2"
-thiserror = "1"
+thiserror = "2"
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "logging", "ring"] }
 tokio-util = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ happy-eyeballs = { version = "0.2", default-features = false }
 human-panic = "2"
 notify = "7"
 pretty_assertions = "1"
-pyo3 = { version = "0.22", features = ["experimental-async", "py-clone"] }
-pyo3-async-runtimes = { version = "0.22", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.23", features = ["experimental-async", "py-clone"] }
+pyo3-async-runtimes = { version = "0.23", features = ["attributes", "tokio-runtime"] }
 pyo3-pylogger = "0.3"
 ratatui = { version = "0.29", default-features = false }
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A terminal [MUD] client with a customizable interface and Python scripting.
 >
 > Here be dragons^H^H^H^H^H^H^Hrabid saber-toothed mudpuppys.
 
+https://github.com/user-attachments/assets/d89ade8d-7a36-4f14-8e76-17598aaac9a2
+
 # Features
 
 * **Responsive TUI** - Mudpuppy is a terminal client, but it tries to be more

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ A terminal [MUD] client with a customizable interface and Python scripting.
 
 * **Responsive TUI** - Mudpuppy is a terminal client, but it tries to be more
   like a GUI app. It has a terminal user-interface (TUI) with built-in support
-  for panes, resizable sub-windows, and so on. The TUI scales and redraws
-  as your terminal changes size, making it great for use on mobile over SSH.
+  for panes and resizable sub-windows. The TUI scales and redraws as your
+  terminal changes size, making it great for use on mobile over SSH.
 
 * **Python** - the "py" in "Mudpup**py**" stands for Python :) Instead of Lua,
   or a custom scripting language, Mudpuppy uses Python for customization and
@@ -41,7 +41,7 @@ A terminal [MUD] client with a customizable interface and Python scripting.
 
 * **Async** - triggers, aliases, and other core client functions are
   asynchronous. Your scripts can benefit from the Python `asyncio` ecosystem,
-  making it easy to take complex actions like making HTTP requests without
+  making it easy to take complex actions like sending HTTP requests without
   blocking the client.
 
 * **Multi-Session** - Mudpuppy will let you connect to multiple MUDs with one
@@ -56,13 +56,10 @@ A terminal [MUD] client with a customizable interface and Python scripting.
 
 # Quick Start
 
-1. Download a release:
+1. Build the client from source.
 
-```bash
-# TODO...
-```
-
-Advanced users may want to build from source. TODO: link to instructions.
+Binary releases will be provided in the future, but for now you will need to
+be comfortable installing Rust and building Mudpuppy from source.
 
 2. Create a config file with details for your favourite MUD. The location of the
    file will differ based on your OS.
@@ -89,8 +86,6 @@ host = "dunemud.net"
 port = 6789
 tls = "Disabled"
 ```
-
-See this example config file for more information. TODO: link to config file.
 
 3. Run Mudpuppy from a terminal, and get to hacking'n'slashing:
 

--- a/mudpuppy/python/cmd_alias.py
+++ b/mudpuppy/python/cmd_alias.py
@@ -1,7 +1,6 @@
 import logging
 from argparse import Namespace
 
-from commands import Command, add_command
 from mudpuppy_core import (
     AliasConfig,
     AliasId,
@@ -10,8 +9,9 @@ from mudpuppy_core import (
     SessionId,
     mudpuppy_core,
 )
-
+from commands import Command, add_command
 from mudpuppy import on_new_session
+from cformat import cformat
 
 
 class AliasCmd(Command):
@@ -120,9 +120,14 @@ class AliasCmd(Command):
             label = alias.config.expansion
             if alias.config.callback is not None:
                 label = str(alias.config.callback)
+            prefix = "<green>"
+            if not alias.enabled:
+                prefix = "<red>"
             output_items.append(
                 OutputItem.command_result(
-                    f"{alias.id}: Hits={alias.config.hit_count} {repr(alias.config.pattern())} -> {repr(label)}",
+                    cformat(
+                        f"{prefix}{alias.id}: Enabled={alias.enabled} Hits={alias.config.hit_count} {repr(alias.config.pattern())} -> {repr(label)}<reset>"
+                    ),
                 )
             )
         await mudpuppy_core.add_outputs(sesh_id, output_items)

--- a/mudpuppy/python/cmd_timer.py
+++ b/mudpuppy/python/cmd_timer.py
@@ -2,7 +2,6 @@ import logging
 from argparse import Namespace
 from typing import Optional
 
-from commands import Command, add_command
 from mudpuppy_core import (
     Event,
     OutputItem,
@@ -11,7 +10,8 @@ from mudpuppy_core import (
     TimerId,
     mudpuppy_core,
 )
-
+from commands import Command, add_command
+from cformat import cformat
 from mudpuppy import on_new_session
 
 
@@ -117,9 +117,14 @@ class TimerCmd(Command):
         timers = await mudpuppy_core.timers()
         output_items = []
         for timer in sorted(timers, key=lambda a: a.id):
+            prefix = "<green>"
+            if not timer.running:
+                prefix = "<red>"
             output_items.append(
                 OutputItem.command_result(
-                    f"{timer.id}: Running={timer.running} {timer.config}",
+                    cformat(
+                        f"{prefix}{timer.id}: Running={timer.running} {timer.config}<reset>"
+                    ),
                 )
             )
         await mudpuppy_core.add_outputs(sesh_id, output_items)

--- a/mudpuppy/python/cmd_trigger.py
+++ b/mudpuppy/python/cmd_trigger.py
@@ -1,7 +1,6 @@
 import logging
 from argparse import Namespace
 
-from commands import Command, add_command
 from mudpuppy_core import (
     Event,
     OutputItem,
@@ -10,7 +9,8 @@ from mudpuppy_core import (
     TriggerId,
     mudpuppy_core,
 )
-
+from commands import Command, add_command
+from cformat import cformat
 from mudpuppy import on_new_session
 
 
@@ -156,10 +156,14 @@ class TriggerCmd(Command):
                 label = f"Action={repr(label)}"
             else:
                 label = f"Highlight={str(trigger.config.highlight)}"
-
+            prefix = "<green>"
+            if not trigger.enabled:
+                prefix = "<red>"
             output_items.append(
                 OutputItem.command_result(
-                    f"{trigger.id}: Hits={trigger.config.hit_count} Gag={trigger.config.gag} Prompt={trigger.config.prompt} Pattern={repr(trigger.config.pattern())} {label}",
+                    cformat(
+                        f"{prefix}{trigger.id}: Enabled={trigger.enabled} Hits={trigger.config.hit_count} Gag={trigger.config.gag} Prompt={trigger.config.prompt} Pattern={repr(trigger.config.pattern())} {label}<reset>"
+                    ),
                 )
             )
         await mudpuppy_core.add_outputs(sesh_id, output_items)

--- a/mudpuppy/python/history.py
+++ b/mudpuppy/python/history.py
@@ -68,7 +68,7 @@ class History:
         while self.cursor_pos < len(self.lines) - 1:
             self.cursor_pos += 1
             line = self.lines[self.cursor_pos]
-            skip = line.scripted and skip_scripted
+            skip = line.scripted and skip_scripted or line.sent.strip() == ""
             logging.debug(f"{self} pos updated - line={line}, skip={skip}")
             if skip:
                 continue
@@ -98,7 +98,7 @@ class History:
         while self.cursor_pos > 0:
             self.cursor_pos -= 1
             line = self.lines[self.cursor_pos]
-            skip = line.scripted and skip_scripted
+            skip = line.scripted and skip_scripted or line.sent.strip() == ""
             logging.debug(f"{self} pos updated - line={line}, skip={skip}")
             if skip:
                 continue

--- a/mudpuppy/python/mudpuppy.py
+++ b/mudpuppy/python/mudpuppy.py
@@ -288,7 +288,7 @@ TriggerCallable = Callable[[SessionId, TriggerId, str, Any], Awaitable[None]]
 def trigger(
     *,
     pattern: str,
-    name: Optional[str],
+    name: Optional[str] = None,
     gag: bool = False,
     strip_ansi: bool = True,
     prompt: bool = False,

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -176,6 +176,7 @@ impl Client {
                         None => self.transmit_input(s, futures),
                     }
                 }
+                None => self.transmit_input(String::default(), futures),
                 _ => Ok(()),
             };
         }
@@ -324,9 +325,6 @@ impl Client {
         match &mud.command_separator {
             Some(sep) => {
                 for fragment in line.sent.split(sep) {
-                    if fragment.trim() == "" {
-                        continue;
-                    }
                     let mut line = line.clone();
                     if line.sent != fragment {
                         line.original = Some(line.sent);

--- a/mudpuppy/src/error.rs
+++ b/mudpuppy/src/error.rs
@@ -77,7 +77,7 @@ impl From<PyErr> for Error {
     fn from(error: PyErr) -> Self {
         Python::with_gil(|py| {
             let traceback = error
-                .traceback_bound(py)
+                .traceback(py)
                 .and_then(|t| t.format().ok())
                 .unwrap_or_default();
             Error::Python { error, traceback }

--- a/mudpuppy/src/tui/layout.rs
+++ b/mudpuppy/src/tui/layout.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 use pyo3::types::{PyAnyMethods, PyDict, PyList, PyListMethods, PyTuple};
-use pyo3::{pyclass, pymethods, Bound, IntoPy, Py, PyRef, Python};
+use pyo3::{pyclass, pymethods, Bound, Py, PyRef, Python};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::widgets::{Borders, Clear};
 use ratatui::Frame;
@@ -117,7 +117,7 @@ impl LayoutNode {
             name: name.to_string(),
             direction: PyDirection::default(),
             margin: 0,
-            sections: Py::from(PyList::empty_bound(py)),
+            sections: Py::from(PyList::empty(py)),
         }
     }
 
@@ -130,9 +130,7 @@ impl LayoutNode {
         constraint: PyConstraint,
     ) -> Result<()> {
         let sections_list = self.sections.bind(py);
-        sections_list
-            .append((constraint.into_py(py), node.into_py(py)))
-            .map_err(Into::into)
+        sections_list.append((constraint, node)).map_err(Into::into)
     }
 
     /// # Errors
@@ -158,7 +156,7 @@ impl LayoutNode {
     /// # Errors
     /// If the layout contains invalid types, or duplicate section names.
     pub fn all_layouts<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>, Error> {
-        let result = PyDict::new_bound(py);
+        let result = PyDict::new(py);
         self.collect_all_layouts(py, &result)?;
         Ok(result)
     }


### PR DESCRIPTION
### python/mudpuppy: fix trigger optional name

Forgot to give the newly `Optional` field a default value of `None`, preventing it from being truly optional. Oops!

### python: skip first tick of timers

The Tokio timer implementation's `tick()` function always yields immediately on the first poll. This is counter to user expectation
because it means when you add a timer with a duration, it will run immediately, not after the duration expires. Work-around this with a quick'n'cheap bool check to skip the first iteration without affecting the tick count.

### python: /alias,/trigger,/timer list show enabled

Does what it says on the tin. Better output formatting still needed.

### client: fix sending empty input lines

This is an important mechanic and is required (for example) when reading a man page on an LP MUD that mimics a "more" utility. It worked previously but regressed when the cmd separator feature landed.

### python/history: skip empty lines

Now that we can send empty lines again, don't bother populating them from history when scrolling previous sent lines. It's not helpful.

### cargo: update thiserror v1 -> v2

The breaking changes mentioned in the [release notes](https://github.com/dtolnay/thiserror/releases/tag/2.0.0) do not apply so this is an in-place update.

### cargo: pyo3 0.22 -> 0.23

See [the migration guide](https://pyo3.rs/v0.23.0/migration#from-022-to-023) for more information. Most of the changes
were simple renames. In one place we were using `IntoPy` in an unnecessary way and so can remove it vs migrate to the new `IntoPyObject` trait. Lastly, the `run()` invocations now take CStrings  and so we make use of the `cstr!` macro from pyo3's ffi module to meet the requirement. An ergonomics hit but we should probably migrate some of these into `mudpuppy_core.py` where we can run Python at init time less awkwardly than as embedded strings.

### tui: filter out non-ANSI control chars

Some code might use sequences like 0x08 (backspace) to try and do more "interesting" terminal outputs. This only works for the most vanilla of terminals (e.g. not a MUD client like Mudlet, or one like Mudpuppy). Strip those control characters instead of letting them corrupt the TUI. 

Notably we *do* want to allow the control sequence that begins ANSI colour since the `into_text()` trait will take care of handling those as ratatui span metadata and not rendering them as-is.

### docs: small README tweaks &  add demo mp4

Could use a more structured "tour" video, but this is better than nothing!
