### PR TITLE
quick keybinding fixes

### DIFF
--- a/mudpuppy/src/app.rs
+++ b/mudpuppy/src/app.rs
@@ -592,6 +592,7 @@ pub trait Tab: Debug + Send + Sync {
     fn draw(&mut self, state: &mut State, frame: &mut Frame<'_>, area: Rect) -> Result<()>;
 }
 
+// TODO(XXX): split into a simple enum for type, and a variant enum for state.
 #[derive(Debug)]
 pub enum TabKind {
     MudList {},
@@ -602,8 +603,8 @@ impl TabKind {
     #[must_use]
     pub fn config_key(&self) -> &'static str {
         match self {
-            Self::MudList {} => "MudList",
-            Self::Session { .. } => "Mud",
+            Self::MudList {} => "mudlist",
+            Self::Session { .. } => "mud",
         }
     }
 }


### PR DESCRIPTION
A larger overhaul is needed but let's stop the bleeding first:

* always treat tabkind used for the key binding mode as lowercase.
* if custom keybindings are present in the config, merge with the defaults, preferring the user binding where there is a conflict.
* print the full set of resolved keybindings afterwards at the trace log level. It's spammy, but that's what trace is for. Use a higher log level if you don't want spam!

Updates https://github.com/mudpuppy-rs/mudpuppy/issues/33