### PR TITLE
app: filter non-press key events earlier

### DIFF
--- a/mudpuppy/src/app.rs
+++ b/mudpuppy/src/app.rs
@@ -12,7 +12,7 @@ use notify::{
 };
 use pyo3::{Py, PyObject, PyResult, Python};
 use ratatui::backend::{Backend, CrosstermBackend};
-use ratatui::crossterm::event::Event as TermEvent;
+use ratatui::crossterm::event::{Event as TermEvent, KeyEventKind};
 use ratatui::crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
@@ -299,6 +299,11 @@ impl App {
         let TermEvent::Key(key_event) = event else {
             return current_tab.term_event(state, event_futures, event);
         };
+
+        // Ignore release & repeat events. These only happen on Windows in practice and we're not that specific.
+        if key_event.kind != KeyEventKind::Press {
+            return Ok(None);
+        }
 
         if let UiState::Error(err) = &state.ui_state {
             if err.fatal() {

--- a/mudpuppy/src/client/input.rs
+++ b/mudpuppy/src/client/input.rs
@@ -3,7 +3,7 @@ use std::{iter, mem};
 
 use pyo3::{pyclass, pymethods};
 use ratatui::crossterm::event::KeyCode::{Backspace, Char, Delete, End, Home, Left, Right};
-use ratatui::crossterm::event::{KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
 use tracing::info;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -33,14 +33,8 @@ pub struct Input {
 impl Input {
     pub fn handle_key_event(&mut self, key_event: &KeyEvent) {
         let KeyEvent {
-            code,
-            modifiers,
-            kind,
-            ..
+            code, modifiers, ..
         } = key_event;
-        if *kind != KeyEventKind::Press {
-            return;
-        }
 
         match (code, *modifiers) {
             (Backspace, KeyModifiers::NONE) | (Char('h'), KeyModifiers::CONTROL) => {

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use futures::stream::FuturesUnordered;
 use pyo3::{pyclass, pymethods, Py, PyRefMut, Python};
-use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use serde::Serialize;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, info, instrument, trace, warn, Level};
@@ -160,7 +160,6 @@ impl Client {
         // If the key event was Enter being pressed, send the queued input.
         if let &KeyEvent {
             code: KeyCode::Enter,
-            kind: KeyEventKind::Press,
             ..
         } = event
         {


### PR DESCRIPTION
Previously I tried to fix a Windows-specific duplicated key press glitch by filtering out the non-press events in the input TUI code. In practice this needs to be done earlier so it applies globally: for all widgets, and the Python events produced for key presses.

This fixes glitchy behaviour on Windows where (for example) pressing F5 to hide a custom layout UI element would flicker it, or pressing CTRL-N/CTRL-P to change tabs would skip multiple tabs.