### PR TITLE
Explicitly set file encoding in gmcp_channels.py example

### DIFF
--- a/python-examples/gmcp_channels.py
+++ b/python-examples/gmcp_channels.py
@@ -37,7 +37,7 @@ class ChannelLogger:
         self.logfile_path = Path(channel_log_dir, f"{mudname}.log")
 
         # Open for reading/appending.
-        self.logfile = open(self.logfile_path, "a")
+        self.logfile = open(self.logfile_path, "a", encoding="utf-8")
 
     def __del__(self, *args):
         if not self.logfile.closed:


### PR DESCRIPTION
Some system locales are not utf-8 friendly, so we can avoid exceptions when logging gmcp chat that contains unicode characters by explictly setting the encoding for the log file.