### PR TITLE
Fix argument names

### DIFF
--- a/mudpuppy/src/python.rs
+++ b/mudpuppy/src/python.rs
@@ -832,9 +832,9 @@ impl PyApp {
         })
     }
 
-    fn stop_timer<'py>(&self, py: Python<'py>, id: u32) -> PyResult<Bound<'py, PyAny>> {
+    fn stop_timer<'py>(&self, py: Python<'py>, timer_id: u32) -> PyResult<Bound<'py, PyAny>> {
         with_state!(self, py, |mut state| {
-            match state.timers.get_mut(id) {
+            match state.timers.get_mut(timer_id) {
                 Some(timer) => {
                     if timer.running {
                         timer.running = false;
@@ -845,29 +845,29 @@ impl PyApp {
 
                     Ok(())
                 }
-                None => Err(Error::Timer(TimerError::UnknownId(id)).into()),
+                None => Err(Error::Timer(TimerError::UnknownId(timer_id)).into()),
             }
         })
     }
 
-    fn get_timer<'py>(&self, py: Python<'py>, id: u32) -> PyResult<Bound<'py, PyAny>> {
+    fn get_timer<'py>(&self, py: Python<'py>, timer_id: u32) -> PyResult<Bound<'py, PyAny>> {
         with_state!(self, py, |state| Python::with_gil(|_| {
-            Ok(state.timers.get(id).cloned())
+            Ok(state.timers.get(timer_id).cloned())
         }))
     }
 
-    fn remove_timer<'py>(&self, py: Python<'py>, id: u32) -> PyResult<Bound<'py, PyAny>> {
+    fn remove_timer<'py>(&self, py: Python<'py>, timer_id: u32) -> PyResult<Bound<'py, PyAny>> {
         with_state!(self, py, |mut state| {
             let timer = state
                 .timers
-                .get_mut(id)
-                .ok_or(Error::Timer(TimerError::UnknownId(id)))?;
+                .get_mut(timer_id)
+                .ok_or(Error::Timer(TimerError::UnknownId(timer_id)))?;
             if timer.running {
                 timer.running = false;
                 timer.stop_tx.send(true).ok();
             }
-            info!("removed timer {id}");
-            state.timers.remove(id);
+            info!("removed timer {timer_id}");
+            state.timers.remove(timer_id);
             Ok(())
         })
     }

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -1719,7 +1719,7 @@ class MudpuppyCore:
         """
         ...
 
-    async def new_alias(self, id: int, config: AliasConfig, module: str) -> int:
+    async def new_alias(self, session_id: int, config: AliasConfig, module: str) -> int:
         """
         Creates a new `Alias` for the given session ID for the given `AliasConfig`.
 

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -2057,7 +2057,7 @@ class MudpuppyCore:
         """
         ...
 
-    async def emit_event(self, custom_type: str, data: Any, id: Optional[int]):
+    async def emit_event(self, custom_type: str, data: Any, session_id: Optional[int]):
         """
         Emits a custom event with the given `custom_type` and `data` for the given session ID.
         If `id` is `None`, the event is emitted for all sessions.


### PR DESCRIPTION
Update some python stubs to use correct argument name for session_id and change timer functions id arguments to the more descriptive timer_id name.