### PR TITLE
rework Input API, add markup, spellcheck example

### DIFF
--- a/mudpuppy/src/python.rs
+++ b/mudpuppy/src/python.rs
@@ -914,50 +914,15 @@ impl PyApp {
         })
     }
 
-    fn get_input<'py>(&self, py: Python<'py>, session_id: u32) -> PyResult<Bound<'py, PyAny>> {
-        with_state!(self, py, |state| {
-            Ok(state
-                .client_for_id(session_id)
-                .ok_or(Error::UnknownSession(session_id))?
-                .input
-                .value())
-        })
-    }
-
-    fn get_input_echo<'py>(&self, py: Python<'py>, session_id: u32) -> PyResult<Bound<'py, PyAny>> {
-        with_state!(self, py, |state| {
-            Ok(state
-                .client_for_id(session_id)
-                .ok_or(Error::UnknownSession(session_id))?
-                .input
-                .telnet_echo())
-        })
-    }
-
-    fn set_input<'py>(
-        &self,
-        py: Python<'py>,
-        session_id: u32,
-        input: InputLine,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn input<'py>(&self, py: Python<'py>, session_id: u32) -> PyResult<Bound<'py, PyAny>> {
         with_state!(self, py, |mut state| {
-            state
-                .client_for_id_mut(session_id)
-                .ok_or(Error::UnknownSession(session_id))?
-                .input
-                .set_value(input);
-            Ok(())
-        })
-    }
-
-    fn clear_input<'py>(&self, py: Python<'py>, session_id: u32) -> PyResult<Bound<'py, PyAny>> {
-        with_state!(self, py, |mut state| {
-            state
-                .client_for_id_mut(session_id)
-                .ok_or(Error::UnknownSession(session_id))?
-                .input
-                .reset();
-            Ok(())
+            Python::with_gil(|_| {
+                Ok(state
+                    .client_for_id_mut(session_id)
+                    .ok_or(Error::UnknownSession(session_id))?
+                    .input
+                    .clone())
+            })
         })
     }
 

--- a/mudpuppy/src/tui/input.rs
+++ b/mudpuppy/src/tui/input.rs
@@ -1,13 +1,12 @@
+use crate::client::input as client_input;
+use crate::error::Error;
+use crate::Result;
+use ansi_to_tui::IntoText;
 use ratatui::layout::{Position, Rect};
 use ratatui::prelude::{Color, Style};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
 use std::collections::HashMap;
-
-use crate::client::input as client_input;
-use crate::client::input::EchoState;
-use crate::error::Error;
-use crate::Result;
 
 #[derive(Debug, Default)]
 pub(super) struct Input {}
@@ -22,19 +21,12 @@ impl Input {
             .get(INPUT_SECTION_NAME)
             .ok_or(Error::LayoutMissing(INPUT_SECTION_NAME.to_string()))?;
 
-        let content = input.value();
-        let mut content_str = content.sent;
-        if content_str.is_empty() && content.original.is_some() {
-            content_str = content.original.unwrap();
-        }
-
-        if content.echo == EchoState::Password {
-            content_str = "*".repeat(content_str.len());
-        }
-
         let width = area.width.max(3) - 3;
         let scroll = input.visual_scroll(width as usize);
-        let input_text = Paragraph::new(content_str.as_str())
+
+        let input_text = input.decorated_value().into_text()?;
+
+        let input_text = Paragraph::new(input_text)
             .block(
                 Block::default()
                     .borders(Borders::ALL)

--- a/mudpuppy/src/tui/input.rs
+++ b/mudpuppy/src/tui/input.rs
@@ -1,12 +1,14 @@
-use crate::client::input as client_input;
-use crate::error::Error;
-use crate::Result;
+use std::collections::HashMap;
+
 use ansi_to_tui::IntoText;
 use ratatui::layout::{Position, Rect};
 use ratatui::prelude::{Color, Style};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
-use std::collections::HashMap;
+
+use crate::client::input as client_input;
+use crate::error::Error;
+use crate::Result;
 
 #[derive(Debug, Default)]
 pub(super) struct Input {}

--- a/mudpuppy/src/tui/mudlist.rs
+++ b/mudpuppy/src/tui/mudlist.rs
@@ -64,7 +64,7 @@ impl Widget {
     fn draw_help(frame: &mut Frame<'_>, area: Rect) {
         let help_text: Vec<Line> = vec![
             format!(
-                "* Edit {:?} to add/edit/remove MUDs. This list will reload automatically.",
+                "* Edit {} to add/edit/remove MUDs. This list will reload automatically.",
                 config_file().display()
             )
             .into(),

--- a/mudpuppy/src/tui/session.rs
+++ b/mudpuppy/src/tui/session.rs
@@ -157,7 +157,7 @@ impl Tab for Widget {
         }
 
         // Draw the input area.
-        Input::draw(&mut client.input, frame, &sections)?;
+        Python::with_gil(|py| Input::draw(&mut client.input.borrow_mut(py), frame, &sections))?;
 
         // Draw the main output buffer.
         self.mud_buffer

--- a/python-examples/spellcheck.py
+++ b/python-examples/spellcheck.py
@@ -1,0 +1,65 @@
+import logging
+
+from mudpuppy import on_event
+from mudpuppy_core import mudpuppy_core, Event, EventType, Input, EchoState
+from cformat import cformat
+from commands import commands  # type: ignore  # TODO(XXX): .pyi for commands
+
+
+@on_event(EventType.KeyPress)
+async def markup_input(event: Event):
+    """
+    An example KeyPress handler that adds markup to highlight input based on
+    spellchecking and slash command status.
+    """
+    assert isinstance(event, Event.KeyPress)
+
+    i = await mudpuppy_core.input(event.id)
+    if i.telnet_echo() == EchoState.Password:
+        i.clear_markup()
+        return  # Don't try to spellcheck/highlight masked password entry!
+
+    to_be_sent = i.value().sent
+    if len(to_be_sent) <= 1:
+        return
+
+    spellcheck_input(event.id, i, to_be_sent.split())
+
+
+def highlight_cmd(session_id: int, i: Input, cmd: str):
+    # Check if the command is valid.
+    valid = commands[session_id].get(cmd[1:])
+
+    # Add the appropriate markup to the command part.
+    i.add_markup(0, cformat("<bold><green>") if valid else cformat("<bold><red>"))
+    i.add_markup(len(cmd), cformat("<reset>"))
+
+
+def spellcheck_input(session_id: int, i: Input, parts: list[str]):
+    i.clear_markup()
+
+    start = 0
+    for part in parts:
+        end = start + len(part)
+        # remove leading/trailing punctuation for a dictionary lookup.
+        clean_part = part.strip(".,!?;:'\"`[]{}()\\/<>~!@#$%^&*_-+=").lower()
+        if start == 0 and part.startswith("/"):
+            # If the first part is a slash command, highlight it specially instead of spellchecking.
+            highlight_cmd(session_id, i, part)
+        elif dictionary is not None and not dictionary.lookup(clean_part):
+            # logging.debug(f"misspelled word: {clean_part} ({start}, {end})")
+            i.add_markup(start, cformat("<bold><red>"))
+            i.add_markup(end, cformat("<reset>"))
+
+        start = end + 1  # Offset by 1 to account for the space between words.
+
+
+try:
+    from spylls.hunspell import Dictionary  # type: ignore
+
+    # TODO(XXX): support other languages
+    dictionary = Dictionary.from_files("en_US")
+except ImportError:
+    logging.warning("spylls is not in the PYTHONPATH. Spellchecking will be disabled.")
+    logging.warning("perhaps you need to 'pip install spylls'?")
+    dictionary = None

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -1467,6 +1467,149 @@ class Gauge:
         """
         ...
 
+class Input:
+    """
+    The input area of the client window.
+    """
+
+    def value(self) -> InputLine:
+        """
+        Returns the current value of the input area.
+        """
+        ...
+
+    def cursor(self) -> int:
+        """
+        Returns the current cursor position in the input area.
+        """
+        ...
+
+    def visual_cursor(self) -> int:
+        """
+        Returns the visual cursor position in the input area.
+        """
+        ...
+
+    def visual_scroll(self, width: int) -> int:
+        """
+        Returns the visual scroll position in the input area.
+        """
+        ...
+
+    def telnet_echo(self) -> EchoState:
+        """
+        Returns the current telnet echo state of the input area.
+        """
+        ...
+
+    def reset(self):
+        """
+        Resets the input area to its default state.
+        """
+        ...
+
+    def pop(self) -> Optional[InputLine]:
+        """
+        Removes and returns the input from the input area.
+        """
+        ...
+
+    def set_value(self, value: InputLine):
+        """
+        Sets the value of the input area, adjusting the cursor to the end.
+        """
+        ...
+
+    def set_telnet_echo(self, state: EchoState):
+        """
+        Sets the telnet echo state of the input area.
+        """
+        ...
+
+    def set_cursor(self, pos: int):
+        """
+        Sets the cursor position in the input area.
+        """
+        ...
+
+    def insert(self, c: str):
+        """
+        Inserts a character at the cursor position.
+        """
+        ...
+
+    def delete_prev(self):
+        """
+        Deletes the character before the cursor.
+        """
+        ...
+
+    def delete_next(self):
+        """
+        Deletes the character after the cursor.
+        """
+        ...
+
+    def delete_word_left(self):
+        """
+        Deletes the word to the left of the cursor.
+        """
+        ...
+
+    def delete_word_right(self):
+        """
+        Deletes the word to the right of the cursor.
+        """
+        ...
+
+    def delete_to_end(self):
+        """
+        Deletes from the cursor to the end of the input.
+        """
+        ...
+
+    def cursor_left(self):
+        """
+        Moves the cursor left.
+        """
+        ...
+
+    def cursor_right(self):
+        """
+        Moves the cursor right.
+        """
+        ...
+
+    def cursor_word_left(self):
+        """
+        Moves the cursor to the left word boundary.
+        """
+        ...
+
+    def cursor_word_right(self):
+        """
+        Moves the cursor to the right word boundary.
+        """
+        ...
+
+    def cursor_start(self):
+        """
+        Moves the cursor to the start of the input.
+        """
+        ...
+
+    def cursor_end(self):
+        """
+        Moves the cursor to the end of the input.
+        """
+        ...
+
+    def drop_index(self, index: int):
+        """
+        Drops the character at the given index.
+        """
+        ...
+
 class MudpuppyCore:
     def config(self) -> Config:
         """
@@ -1865,46 +2008,12 @@ class MudpuppyCore:
         """
         ...
 
-    async def get_input(self, session_id: int) -> InputLine:
+    async def input(self, session_id: int) -> Input:
         """
-        Returns the current input line for the given session ID.
+        Returns the `Input` for the given session ID.
 
-        This is the data that has been typed in by the user into the input area,
-        but not yet transmitted to the MUD.
-
-        Use `MudpuppyCore.set_input()` to replace this yet-to-be-sent input.
-        """
-        ...
-
-    async def get_input_echo(self, session_id: int) -> EchoState:
-        """
-        Returns the current telnet echo state for the given session ID.
-
-        This indicates whether the MUD told us to stop echoing input because
-        sensitive data is being entered.
-        """
-        ...
-
-    async def set_input(self, session_id: int, new_input: InputLine):
-        """
-        Sets the current input line for the given session ID.
-
-        This is the data that has been typed in by the user into the input area,
-        but not yet transmitted to the MUD.
-
-        Use `MudpuppyCore.get_input()` to retrieve the current input.
-        """
-        ...
-
-    async def clear_input(self, session_id: int):
-        """
-        Clears the current input line for the given session ID.
-
-        This clears the data that has been typed in by the user into the input area,
-        but not yet transmitted to the MUD.
-
-        Use `MudpuppyCore.set_input()` to set the current input and `MudpuppyCore.get_input()`
-        to retrieve the current input.
+        The `Input` provides access to queued input typed by the user and has
+        functions to query/edit/replace that input.
         """
         ...
 
@@ -2567,149 +2676,6 @@ class PromptMode:
         """
         The `PromptSignal` used to indicate prompt lines.
         """
-
-class Input:
-    """
-    The input area of the client window.
-    """
-
-    def value(self) -> InputLine:
-        """
-        Returns the current value of the input area.
-        """
-        ...
-
-    def cursor(self) -> int:
-        """
-        Returns the current cursor position in the input area.
-        """
-        ...
-
-    def visual_cursor(self) -> int:
-        """
-        Returns the visual cursor position in the input area.
-        """
-        ...
-
-    def visual_scroll(self, width: int) -> int:
-        """
-        Returns the visual scroll position in the input area.
-        """
-        ...
-
-    def telnet_echo(self) -> EchoState:
-        """
-        Returns the current telnet echo state of the input area.
-        """
-        ...
-
-    def reset(self):
-        """
-        Resets the input area to its default state.
-        """
-        ...
-
-    def pop(self) -> Optional[InputLine]:
-        """
-        Removes and returns the input from the input area.
-        """
-        ...
-
-    def set_value(self, value: InputLine):
-        """
-        Sets the value of the input area, adjusting the cursor to the end.
-        """
-        ...
-
-    def set_telnet_echo(self, state: EchoState):
-        """
-        Sets the telnet echo state of the input area.
-        """
-        ...
-
-    def set_cursor(self, pos: int):
-        """
-        Sets the cursor position in the input area.
-        """
-        ...
-
-    def insert(self, c: str):
-        """
-        Inserts a character at the cursor position.
-        """
-        ...
-
-    def delete_prev(self):
-        """
-        Deletes the character before the cursor.
-        """
-        ...
-
-    def delete_next(self):
-        """
-        Deletes the character after the cursor.
-        """
-        ...
-
-    def delete_word_left(self):
-        """
-        Deletes the word to the left of the cursor.
-        """
-        ...
-
-    def delete_word_right(self):
-        """
-        Deletes the word to the right of the cursor.
-        """
-        ...
-
-    def delete_to_end(self):
-        """
-        Deletes from the cursor to the end of the input.
-        """
-        ...
-
-    def cursor_left(self):
-        """
-        Moves the cursor left.
-        """
-        ...
-
-    def cursor_right(self):
-        """
-        Moves the cursor right.
-        """
-        ...
-
-    def cursor_word_left(self):
-        """
-        Moves the cursor to the left word boundary.
-        """
-        ...
-
-    def cursor_word_right(self):
-        """
-        Moves the cursor to the right word boundary.
-        """
-        ...
-
-    def cursor_start(self):
-        """
-        Moves the cursor to the start of the input.
-        """
-        ...
-
-    def cursor_end(self):
-        """
-        Moves the cursor to the end of the input.
-        """
-        ...
-
-    def drop_index(self, index: int):
-        """
-        Drops the character at the given index.
-        """
-        ...
 
 type EventHandler = Callable[[Event], Awaitable[None]]
 """

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -1610,6 +1610,31 @@ class Input:
         """
         ...
 
+    def add_markup(self, index: int, ansi_markup: str):
+        """
+        Adds the provided ansi_markup as a decoration to the input area at the given index.
+        """
+
+    def remove_markup(self, index: int):
+        """
+        Removes the ansi_markup decoration from the given index.
+        """
+
+    def clear_markup(self):
+        """
+        Clears all ansi_markup decorations from the input area.
+        """
+
+    def markup(self) -> dict[int, str]:
+        """
+        Returns a dictionary of ansi_markup decorations in the input area.
+        """
+
+    def decorated_value(self) -> str:
+        """
+        Returns the input area's value with the ANSI markup interposed at the correct positions.
+        """
+
 class MudpuppyCore:
     def config(self) -> Config:
         """


### PR DESCRIPTION
### expose Input struct directly to Python scripts

This means moving from holding `Input` to `Py<Input>` in the `Client` struct, and acquiring the GIL for use from Rust. This was my original intent (`Input` is already a pyclass and has stubs!) and it simplifies the `mudpuppy_core` API from the Python side. The `history.py` built-in module shows the improvement nicely. 

## input area markup API, spellcheck example

Adds new `Input` APIs for decorating the to-be-sent queued input text with ANSI colour:

* `add_markup(idx, str)`
* `remove_markup(idx)`
* `clear_markup()`
* `markup() -> dict[int, str]`
* `decorated_value() -> str`

The markup text is interleaved when displaying the text in the TUI (or when `decorated_value()` is used), but it is kept separate from the data transmitted to the MUD.

An example is provided that uses a key event handler to provide highlighting of known slash commands. Additionally, if the `spylls` Python package is installed, it will do spellchecking of input text (`en_US` only for the example) to highlight misspelled words. A more fully featured spellchecker is probably best done as a separate Python package.