### PR TITLE
user guide IDE doc expansion, initial mouse support & mouse scrolling.

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -16,8 +16,11 @@
 # tls = "Disabled"
 
 # Uncomment to enable mouse mode. This may interfere with normal text selection for copy/pasting
-# and may not work in all terminals.
-# mouse = true
+# and may not work in all terminals. Requires restarting Mudpuppy to change.
+# mouse_enabled = true
+
+# Uncomment to enable scrolling buffer history with the mouse wheel. Requires mouse_enabled = true.
+# mouse_scroll = true
 
 [[binding]]
 mode = "mudlist"

--- a/.config/config.toml
+++ b/.config/config.toml
@@ -15,6 +15,10 @@
 # port = 6789
 # tls = "Disabled"
 
+# Uncomment to enable mouse mode. This may interfere with normal text selection for copy/pasting
+# and may not work in all terminals.
+# mouse = true
+
 [[binding]]
 mode = "mudlist"
 keys = "up"

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
         "type": "github"
       },
       "original": {
@@ -73,14 +73,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "nixpkgs_2": {
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738290352,
-        "narHash": "sha256-YKOHUmc0Clm4tMV8grnxYL4IIwtjTayoq/3nqk0QM7k=",
+        "lastModified": 1738981474,
+        "narHash": "sha256-YIELTXxfATG0g1wXjyaOWA4qrlubds3MG4FvMPCxSGg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b031b584125d33d23a0182f91ddbaf3ab4880236",
+        "rev": "5c571e5ff246d8fc5f76ba6e38dc8edb6e4002fe",
         "type": "github"
       },
       "original": {

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -8,6 +8,7 @@ use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crossterm::event::MouseEvent;
 use futures::stream::FuturesUnordered;
 use pyo3::{pyclass, pymethods, Py, PyRefMut, Python};
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
@@ -179,6 +180,18 @@ impl Client {
                 key: model_event,
             })?;
         }
+        Ok(())
+    }
+
+    pub fn mouse_event(
+        &mut self,
+        _futures: &mut FuturesUnordered<python::PyFuture>,
+        event: &MouseEvent,
+    ) -> Result<(), Error> {
+        debug!("mouse event: {event:?}");
+
+        // TODO(XXX): process mouse events.
+
         Ok(())
     }
 

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -24,8 +24,8 @@ use crate::config::GlobalConfig;
 use crate::error::Error;
 use crate::idmap::{IdMap, Identifiable};
 use crate::model::{
-    Alias, AliasConfig, InputLine, KeyEvent as PyKeyEvent, MudLine, PromptMode, PromptSignal,
-    SessionInfo, Trigger, TriggerConfig,
+    Alias, AliasConfig, InputLine, KeyEvent as PyKeyEvent, MouseEvent as PyMouseEvent, MudLine,
+    PromptMode, PromptSignal, SessionInfo, Trigger, TriggerConfig,
 };
 use crate::net::telnet::codec::{Item as TelnetItem, Negotiation};
 use crate::net::{connection, stream, telnet};
@@ -188,9 +188,13 @@ impl Client {
         _futures: &mut FuturesUnordered<python::PyFuture>,
         event: &MouseEvent,
     ) -> Result<(), Error> {
-        debug!("mouse event: {event:?}");
-
-        // TODO(XXX): process mouse events.
+        if let Ok(mouse_event) = PyMouseEvent::try_from(*event) {
+            //debug!("mouse event: {mouse_event}");
+            self.event_tx.send(python::Event::Mouse {
+                id: self.info.id,
+                event: mouse_event,
+            })?;
+        }
 
         Ok(())
     }

--- a/mudpuppy/src/config/config_file.rs
+++ b/mudpuppy/src/config/config_file.rs
@@ -95,8 +95,17 @@ impl GlobalConfig {
 pub struct Config {
     #[serde(default)]
     pub muds: Vec<Mud>,
+
+    /// Defaults to off - interferes with copy/paste!
     #[serde(default)]
-    pub mouse_enabled: bool, // Defaults to off - interferes with copy/paste!
+    pub mouse_enabled: bool,
+
+    /// Defaults to off, requires `mouse_enabled`.
+    ///
+    /// Translates mouse scroll events to `Shortcut::ScrollUp` and `Shortcut::ScrollDown` events.
+    #[serde(default)]
+    pub mouse_scroll: bool,
+
     #[serde(default, flatten)]
     pub keybindings: KeyBindings,
 }

--- a/mudpuppy/src/config/config_file.rs
+++ b/mudpuppy/src/config/config_file.rs
@@ -95,6 +95,8 @@ impl GlobalConfig {
 pub struct Config {
     #[serde(default)]
     pub muds: Vec<Mud>,
+    #[serde(default)]
+    pub mouse_enabled: bool, // Defaults to off - interferes with copy/paste!
     #[serde(default, flatten)]
     pub keybindings: KeyBindings,
 }

--- a/mudpuppy/src/model.rs
+++ b/mudpuppy/src/model.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 use std::time::Duration;
 
+use crossterm::event::{MouseEvent, MouseEventKind};
 use pyo3::{pyclass, pymethods, Py, PyAny, PyObject, PyRef, Python};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -392,6 +393,24 @@ impl Shortcut {
 
     fn __repr__(&self) -> String {
         format!("{self:?}")
+    }
+}
+
+impl TryFrom<MouseEvent> for Shortcut {
+    type Error = ();
+
+    fn try_from(event: MouseEvent) -> Result<Self, Self::Error> {
+        Ok(match event {
+            MouseEvent {
+                kind: MouseEventKind::ScrollUp,
+                ..
+            } => Self::ScrollUp,
+            MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                ..
+            } => Self::ScrollDown,
+            _ => return Err(()),
+        })
     }
 }
 

--- a/mudpuppy/src/tui/session.rs
+++ b/mudpuppy/src/tui/session.rs
@@ -124,11 +124,17 @@ impl Tab for Widget {
             return Ok(None);
         };
 
-        let TermEvent::Key(key_event) = event else {
-            return Ok(None);
-        };
+        match event {
+            TermEvent::Key(key_event) => {
+                client.key_event(futures, key_event)?;
+            }
+            TermEvent::Mouse(mouse_event) => {
+                client.mouse_event(futures, mouse_event)?;
+            }
+            _ => {}
+        }
 
-        client.key_event(futures, key_event).map(|()| None)
+        Ok(None)
     }
 
     fn draw(&mut self, state: &mut State, frame: &mut Frame<'_>, area: Rect) -> Result<()> {

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -12,6 +12,8 @@ __all__ = [
     "Mud",
     "Tls",
     "KeyEvent",
+    "MouseEvent",
+    "MouseEventKind",
     "KeyBindings",
     "MudLine",
     "InputLine",
@@ -130,6 +132,78 @@ class KeyEvent:
     def modifiers(self) -> list[str]:
         """
         Return a list of key modifiers active for the key code.
+
+        Example: "ctrl", "shift", "alt"
+        """
+
+class MouseEventKind(StrEnum):
+    """
+    An enum describing possible `MouseEvent` types.
+    """
+
+    LeftButtonDown = auto()
+    """
+    The left mouse button was pressed.
+    """
+
+    RightButtonDown = auto()
+    """
+    The right mouse button was pressed.
+    """
+
+    MiddleButtonDown = auto()
+    """
+    The middle mouse button was pressed.
+    """
+
+    Moved = auto()
+    """
+    The mouse was moved.
+    """
+
+    ScrollDown = auto()
+    """
+    The mouse wheel was scrolled down.
+    """
+
+    ScrollUp = auto()
+    """
+    The mouse wheel was scrolled up.
+    """
+
+    ScrollLeft = auto()
+    """
+    The mouse wheel was scrolled left.
+    """
+
+    ScrollRight = auto()
+    """
+    The mouse wheel was scrolled right.
+    """
+
+class MouseEvent:
+    """
+    A mouse event.
+    """
+
+    kind: MouseEventKind
+    """
+    The `MouseEventKind` of mouse event that occurred.
+    """
+
+    column: int
+    """
+    The terminal column where the event occurred.
+    """
+
+    row: int
+    """
+    The terminal row where the event occurred.
+    """
+
+    def modifiers(self) -> list[str]:
+        """
+        Return a list of key modifiers active for the mouse event.
 
         Example: "ctrl", "shift", "alt"
         """
@@ -2306,6 +2380,11 @@ class EventType(StrEnum):
     An event emitted when a keyboard key was pressed.
     """
 
+    Mouse = auto()
+    """
+    An event emitted when there is mouse activity.
+    """
+
     Python = auto()
     """
     A custom event was emitted by a Python script.
@@ -2553,6 +2632,22 @@ class Event:
         key: KeyEvent
         """
         The `KeyEvent` describing the key that was pressed.
+        """
+
+    class Mouse:
+        """
+        An `EventType.Mouse` event. This is produced when there is mouse activity and the Mudpuppy config has
+        `mouse_enabled` set to `true`.
+        """
+
+        id: int
+        """
+        The session ID that received the mouse activity.
+        """
+
+        event: MouseEvent
+        """
+        The `MouseEvent` describing the mouse activity.
         """
 
     class GmcpEnabled:

--- a/user-guide/src/SUMMARY.md
+++ b/user-guide/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Config](config/README.md)
      - [MUDs](config/muds.md)
      - [Keybindings](config/keybindings.md)
+     - [Mouse support](config/mouse.md)
 - [Input](input.md)
 - [Commands](commands.md)
 - [Logging](logging.md)

--- a/user-guide/src/config/README.md
+++ b/user-guide/src/config/README.md
@@ -37,6 +37,8 @@ MUDPUPPY_CONFIG=$HOME/mudpuppy-test/config MUDPUPPY_DATA=$HOME/mudpuppy-test/dat
 ### Example Config
 
 ```toml
+mouse_enabled = false
+
 [[muds]]
 name = "DuneMUD (TLS)"
 host = "dunemud.net"
@@ -47,6 +49,8 @@ tls = "Enabled"
 keys = "shift-up"
 action = "scrolltop"
 ```
+
+See [Mouse support](./mouse.md) for more information on `mouse_enabled`.
 
 See [MUDs](./muds.md) for more information on the MUD config fields.
 

--- a/user-guide/src/config/mouse.md
+++ b/user-guide/src/config/mouse.md
@@ -21,3 +21,18 @@ copy/paste. Support for mouse mode varies by terminal.
 
 [MUD]: ./muds.md
 [Keybinding]: ./keybindings.md
+
+## Mouse Scrolling
+
+When `mouse_enabled` is `true` you can choose whether or not mouse scroll events
+are used to scroll the output history scrollback buffer using the global setting
+`mouse_scroll`. For example:
+
+```toml
+# Enable mouse support, and mouse scrolling of output history
+mouse_enabled = true
+mouse_scroll = true
+```
+
+You can change `mouse_scroll` without restarting Mudpuppy, but remeber that
+changes to `mouse_enabled` require a restart.

--- a/user-guide/src/config/mouse.md
+++ b/user-guide/src/config/mouse.md
@@ -1,0 +1,23 @@
+# Mouse support
+
+You can optionally enable mouse support in Mudpuppy in your `config.toml` with
+the global setting `mouse_enabled`. For example:
+
+```toml
+# Enable mouse support
+mouse_enabled = true
+```
+
+Make sure this configuration is outside of any [MUD] or [Keybinding] stanzas in
+your config TOML.
+
+Note that unlike other settings, you **must** restart Mudpuppy for a change to
+`mouse_enabled` to take effect.
+
+<div class="warning">
+<strong>Important:</strong> mouse mode often interferes with selecting text to
+copy/paste. Support for mouse mode varies by terminal.
+</div>
+
+[MUD]: ./muds.md
+[Keybinding]: ./keybindings.md

--- a/user-guide/src/scripting/editing.md
+++ b/user-guide/src/scripting/editing.md
@@ -7,36 +7,19 @@ APIs.
 Since the Mudpuppy APIs are only exposed from inside of Mudpuppy this requires
 a little bit of special configuration to tell your IDE where to find "[stub
 files]" describing the API. How you do this depends on the specific IDE or
-tool. This page describes doing it with [VSCode].
+tool. This page describes doing it with [VSCode], [PyCharm] and [Pyright].
 
 In both cases you'll need the `.pyi` stub files from the [Mudpuppy GitHub
 repo]. You can find them under the [python-stubs] directory.
 
 [stub files]: <https://mypy.readthedocs.io/en/stable/stubs.html>
 [VSCode]: https://code.visualstudio.com/
+[PyCharm]: https://www.jetbrains.com/pycharm/
+[Pyright]: https://github.com/microsoft/pyright
 [Mudpuppy GitHub repo]: https://github.com/mudpuppy-rs/mudpuppy
 [python-stubs]: https://github.com/mudpuppy-rs/mudpuppy/tree/main/python-stubs
 
-
-## Visual Studio Code
-
-### Python extension
-
-You'll want to use the **Python** VSCode extension for editing Mudpuppy python
-scripts. It comes with the **Pylance** extension that will be used for
-type checking.
-
-After installing the extension:
-
-1. Click on `File` -> `Options` -> `Settings`
-2. Search for the `python.languageServer` option; select '**Pylance**'.
-3. Restart VS Code.
-
-See the [VSCode python docs] for more information.
-
-[VSCode python docs]: https://code.visualstudio.com/docs/languages/python
-
-### Setup stubs
+## Setup Stubs
 
 First, make sure you've taken note of where you cloned Mudpuppy, and the
 location of the `python-stubs` directory inside.
@@ -56,16 +39,37 @@ them as Mudpuppy changes!
 xcopy /E /I \path\to\mudpuppy\python-stubs .\typings
 ```
 
-If you want to use a folder name other than `typings` you'll need to customize
-the `python.analysis.stubPath` option. See the [VSCode settings reference] for
-more information.
+## Visual Studio Code
+
+### Python Extension
+
+You'll want to use the **Python** VSCode extension for editing Mudpuppy python
+scripts. It comes with the **Pylance** extension that will be used for
+type checking.
+
+After installing the extension:
+
+1. Click on `File` -> `Options` -> `Settings`
+2. Search for the `python.languageServer` option; select '**Pylance**'.
+3. Restart VS Code.
+
+### Type Checking
+
+If you've copied the stub files to a directory named `typings` in the root of
+your project, no further configuration is needed. If you want to use a folder
+name other than `typings` you'll need to customize the
+`python.analysis.stubPath` option. See the [VSCode settings reference] and
+[VSCode python docs] for more information.
+
+[VSCode python docs]: https://code.visualstudio.com/docs/languages/python
 
 [VSCode settings reference]: https://code.visualstudio.com/docs/python/settings-reference
 
-### Further customization
+### Missing Module Source Warnings
 
-You may wish to configure the integration further, e.g. to disable missing
-module source warnings.
+Since the Mudpuppy stubs are just that, stubs, they don't have associated source
+code. To stop VSCode from warning you about that we need to customize it
+further:
 
 1. Click on `File` -> `Options` -> `Settings`
 2. Search for the `python.analysis.diagnosticSeverityOverrides` option. We want
@@ -73,7 +77,7 @@ module source warnings.
 3. Restart VS Code.
 
 This is optional, but will clear up any warnings you might see about a missing
-source module. 
+source module.
 
 Here's an example of this section of VS Code's json settings after making the
 change:
@@ -83,3 +87,36 @@ change:
   "reportMissingModuleSource": "none"
 }
 ```
+
+## PyCharm
+
+After copying the stub files into the root of your project you can:
+
+1. Right-click the directory in the project source tree view.
+2. Select "Mark directory as"
+3. Select "Source root"
+
+That's it! You're all set.
+
+For more information see the [PyCharm stubs documentation].
+
+[PyCharm stubs documentation]: https://www.jetbrains.com/help/pycharm/stubs.html
+
+## Pyright
+
+You can also configure a static type checking tool like [Pyright] to use the
+Mudpuppy stubs. This can be helpful for command-line type checking, or CI
+integrations.
+
+1. Install `pyright` with `pip install pyright`
+2. Create (or update) a `pyproject.toml` file at the root of your project with
+   contents:
+```toml
+[tool.pyright]
+stubPath = "typings" # or whatever directory name you used for the stubs
+reportMissingModuleSource = false
+```
+
+See the [Pyright user manual] for more information.
+
+[Pyright user manual]: https://microsoft.github.io/pyright/

--- a/user-guide/src/scripting/editing.md
+++ b/user-guide/src/scripting/editing.md
@@ -1,29 +1,85 @@
-# Python Code Editing
+# IDE Setup for Script Editing
 
-This document serves as a guide to achieve a quality development experience while working with Python in Mudpuppy.
+Once your scripts reach a certain complexity level it's helpful to have a Python
+integrated development environment (IDE) set up that understand the Mudpuppy
+APIs.
+
+Since the Mudpuppy APIs are only exposed from inside of Mudpuppy this requires
+a little bit of special configuration to tell your IDE where to find "[stub
+files]" describing the API. How you do this depends on the specific IDE or
+tool. This page describes doing it with [VSCode].
+
+In both cases you'll need the `.pyi` stub files from the [Mudpuppy GitHub
+repo]. You can find them under the [python-stubs] directory.
+
+[stub files]: <https://mypy.readthedocs.io/en/stable/stubs.html>
+[VSCode]: https://code.visualstudio.com/
+[Mudpuppy GitHub repo]: https://github.com/mudpuppy-rs/mudpuppy
+[python-stubs]: https://github.com/mudpuppy-rs/mudpuppy/tree/main/python-stubs
 
 
 ## Visual Studio Code
 
-Before we configure VS Code for writing Python for Mudpuppy, there are two approaches we can take as it pertains to including the required '.pyi' stubs in our VS Code project:
+### Python extension
 
-1. Create a 'stubs' folder in your project's root directory and create symbolic links for Mudpuppy's stubs in the directory (recommended)
-2. Create a 'stubs' folder in your project's root directory and simply copy Mudpuppy's stubs into the folder (not recommended)
+You'll want to use the **Python** VSCode extension for editing Mudpuppy python
+scripts. It comes with the **Pylance** extension that will be used for
+type checking.
 
-It is recommended that you follow option 1 because of the frequency in which these stubs will change.
+After installing the extension:
 
-The stubs are located at \<mudpuppy-repo-root\>/python-stubs/.
+1. Click on `File` -> `Options` -> `Settings`
+2. Search for the `python.languageServer` option; select '**Pylance**'.
+3. Restart VS Code.
 
-1. Install the '**Python**' extension in VS Code (this should come with the '**Pylance**' extension as well)
-2. Click on File -> Options -> Settings
-3. Search for the `python.languageServer` option; select '**Pylance**'.
-4. Search for the `python.analysis.stubPath` option; put the name of your newly created stubs folder in the option field (a relative path will work).
-5. (Optional) Search for the `python.analysis.diagnosticSeverityOverrides` option. We want to suppress 'reportMissingModuleSource'. Note that this is optional, but will clear up any warnings you might see about a missing source module. Here's an example of this section of VS Code's json settings:
+See the [VSCode python docs] for more information.
+
+[VSCode python docs]: https://code.visualstudio.com/docs/languages/python
+
+### Setup stubs
+
+First, make sure you've taken note of where you cloned Mudpuppy, and the
+location of the `python-stubs` directory inside.
+
+On Linux, MacOS or in WSL, you can **symlink** the Mudpuppy stubs into your
+project directory. That way they're always up to date with your clone of
+Mudpuppy:
 
 ```
+ln -s /path/to/mudpuppy/python-stubs ./typings
+```
+
+If you're on Windows, you can copy the files instead, but remember to update
+them as Mudpuppy changes!
+
+```
+xcopy /E /I \path\to\mudpuppy\python-stubs .\typings
+```
+
+If you want to use a folder name other than `typings` you'll need to customize
+the `python.analysis.stubPath` option. See the [VSCode settings reference] for
+more information.
+
+[VSCode settings reference]: https://code.visualstudio.com/docs/python/settings-reference
+
+### Further customization
+
+You may wish to configure the integration further, e.g. to disable missing
+module source warnings.
+
+1. Click on `File` -> `Options` -> `Settings`
+2. Search for the `python.analysis.diagnosticSeverityOverrides` option. We want
+   to suppress `'reportMissingModuleSource'`.
+3. Restart VS Code.
+
+This is optional, but will clear up any warnings you might see about a missing
+source module. 
+
+Here's an example of this section of VS Code's json settings after making the
+change:
+
+```json
 "python.analysis.diagnosticSeverityOverrides": {
-	"reportMissingModuleSource": "none"
+  "reportMissingModuleSource": "none"
 }
 ```
-6. Restart VS Code.
-


### PR DESCRIPTION
Some quick changes from some afternoon hacking:

* I tweaked and expanded the user guide content for IDE setup started in https://github.com/mudpuppy-rs/mudpuppy/pull/95 - it now covers PyCharm and Pyright in addition to VS Code.

* I bumped the flake inputs, mostly to pick up a fresher nightly rust.

* I added optional mouse support, controlled by a global config bool, `mouse_enabled`, that defaults to off. Mouse support breaks the normal terminal copy/paste interaction so I think it's something best turned on by someone that knows what they want and the side effects (which are described in a new user guide page). Because of the way terminal capability registration is handled presently, changing this option requires a client restart. Might be able to fix that up later but it seemed acceptable for now.

* I added optional mouse scrolling of the scrollback buffer, controlled by a global config bool `mouse_scroll`, that defaults to off and requires `mouse_enabled` to operate. This setting can be changed at runtime without issue. When set to `true`, mouse scroll events are captured and turned into buffer scroll up/down shortcut invocations.

* Finally, a new Python `Event` and `EventType` are added for `Mouse` events. The Python `MouseEvent` class carries the  kind of event (via a `MouseEventKind` enum), the col/row of the event, and any pressed key modifiers. For now we skip passing on mouse button release, or drag events. Just press (for each of the left, right and middle buttons), move, and scroll (left, right, up, and down). The stubs are updated to describe these new bits of Python API.

Should be possible to do some fun stuff with these events in the future, but for now let's get the mouse scrolling code in since it was a feature request from our number 1 user ;-)