### PR TITLE
misc mouse improvements, further prototyping

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -113,6 +113,10 @@ keys = "f3"
 action = "togglelinewrap"
 
 [[binding]]
+keys = "f8"
+action = "ToggleMouseMode"
+
+[[binding]]
 keys = "up"
 action = "historyprevious"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0 # MSRV
+          toolchain: 1.80.0 # MSRV
 
       - name: cargo test (debug; all features)
         run: cargo test --locked --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out.gif
 /todo.txt
 /local
 /test.sh
+recording.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,7 +1191,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "strip-ansi-escapes",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "tokio",
  "tokio-rustls",
@@ -1161,6 +1201,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "tui-framework-experiment",
  "unicode-segmentation",
  "unicode-width 0.2.0",
  "webpki-roots",
@@ -1385,7 +1426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -1549,10 +1590,10 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -1865,7 +1906,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
+dependencies = [
+ "strum_macros 0.27.0",
 ]
 
 [[package]]
@@ -1873,6 +1923,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2223,6 +2286,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-framework-experiment"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743912880bcd21d1034063a1b5c6630d444d5a6cc9f90e2c0a200bbe278907c7"
+dependencies = [
+ "bitflags 2.8.0",
+ "crossterm",
+ "derive_builder",
+ "itertools 0.14.0",
+ "ratatui",
+ "strum 0.27.0",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,7 +2318,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ toml_edit = "0.22"
 tracing = "0.1"
 tracing-error = "0.2"
 tracing-subscriber = "0.3"
+tui-framework-experiment = "0.4"
 unicode-segmentation = "1"
 # See <https://github.com/ratatui/ratatui/issues/1271> for information about why Ratatui pins unicode-width
 unicode-width = "=0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 license = "MIT"
 authors = ["Daniel McCarney <daniel@binaryparadox.net>"]
 homepage = "https://github.com/mudpuppy-rs/mudpuppy"

--- a/mudpuppy/Cargo.toml
+++ b/mudpuppy/Cargo.toml
@@ -44,6 +44,7 @@ toml_edit = { workspace = true }
 tracing = { workspace = true }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "serde"] }
+tui-framework-experiment = { workspace = true }
 unicode-segmentation = { workspace = true, features = [] }
 unicode-width = { workspace = true }
 webpki-roots = { workspace = true }
@@ -61,4 +62,3 @@ assets = [
     ["target/release/mudpuppy", "usr/bin/", "755"],
     ["../README.md", "usr/share/doc/mudpuppy/README", "644"],
 ]
-

--- a/mudpuppy/src/app.rs
+++ b/mudpuppy/src/app.rs
@@ -578,6 +578,20 @@ fn config_reload_event(
         error!("{err}");
         state.ui_state = err.into();
     }
+
+    // Update the mouse capture state.
+    if config.lookup(|c| c.mouse_enabled, false) {
+        if let Err(e) = stdout().execute(crossterm::event::EnableMouseCapture) {
+            error!("failed to enable mouse capture: {e}");
+        }
+        debug!("enabled mouse mode");
+    } else {
+        if let Err(e) = stdout().execute(crossterm::event::DisableMouseCapture) {
+            error!("failed to disable mouse capture: {e}");
+        }
+        debug!("disabled mouse mode");
+    }
+
     // Notify each tab to reprocess the updated config.
     if let Err(err) = tabs.iter_mut().try_for_each(|tab| tab.reload_config()) {
         error!("{err}");

--- a/mudpuppy/src/app.rs
+++ b/mudpuppy/src/app.rs
@@ -819,6 +819,7 @@ fn init_terminal(mouse_enabled: bool) -> io::Result<Terminal<impl Backend>> {
 
 pub(crate) fn restore_terminal() -> Result<()> {
     disable_raw_mode()?;
+    stdout().execute(crossterm::event::DisableMouseCapture)?;
     stdout().execute(LeaveAlternateScreen)?;
     Ok(())
 }

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -30,6 +30,7 @@ use crate::model::{
 use crate::net::telnet::codec::{Item as TelnetItem, Negotiation};
 use crate::net::{connection, stream, telnet};
 use crate::python;
+use crate::tui::button::Button;
 use crate::tui::extrabuffer::ExtraBuffer;
 use crate::tui::gauge::Gauge;
 use crate::tui::layout::LayoutNode;
@@ -49,6 +50,7 @@ pub struct Client {
     pub layout: Py<LayoutNode>,
     pub extra_buffers: IdMap<ExtraBuffer>,
     pub gauges: IdMap<Py<Gauge>>,
+    pub buttons: IdMap<Py<Button>>,
     pub gmcp: Gmcp,
     config: GlobalConfig,
     event_tx: UnboundedSender<python::Event>,
@@ -85,6 +87,7 @@ impl Client {
             layout: session::initial_layout(),
             extra_buffers: IdMap::default(),
             gauges: IdMap::default(),
+            buttons: IdMap::default(),
             gmcp: Gmcp::new(id),
             config,
             event_tx,

--- a/mudpuppy/src/client/mod.rs
+++ b/mudpuppy/src/client/mod.rs
@@ -30,6 +30,7 @@ use crate::model::{
 use crate::net::telnet::codec::{Item as TelnetItem, Negotiation};
 use crate::net::{connection, stream, telnet};
 use crate::python;
+use crate::tui::annotation::Annotation;
 use crate::tui::button::Button;
 use crate::tui::extrabuffer::ExtraBuffer;
 use crate::tui::gauge::Gauge;
@@ -51,6 +52,7 @@ pub struct Client {
     pub extra_buffers: IdMap<ExtraBuffer>,
     pub gauges: IdMap<Py<Gauge>>,
     pub buttons: IdMap<Py<Button>>,
+    pub annotations: IdMap<Py<Annotation>>,
     pub gmcp: Gmcp,
     config: GlobalConfig,
     event_tx: UnboundedSender<python::Event>,
@@ -88,6 +90,7 @@ impl Client {
             extra_buffers: IdMap::default(),
             gauges: IdMap::default(),
             buttons: IdMap::default(),
+            annotations: IdMap::default(),
             gmcp: Gmcp::new(id),
             config,
             event_tx,

--- a/mudpuppy/src/config/config_file.rs
+++ b/mudpuppy/src/config/config_file.rs
@@ -244,4 +244,26 @@ pub fn edit_mud(name: &str, key: &str, v: impl Into<Value> + Debug) -> Result<()
     Ok(())
 }
 
+pub fn edit_global(key: &str, v: impl Into<Value> + Debug) -> Result<()> {
+    let mut config_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .append(false)
+        .open(config_file())?;
+
+    let mut config_data = String::new();
+    config_file.read_to_string(&mut config_data)?;
+    let mut config_doc = config_data
+        .parse::<DocumentMut>()
+        .map_err(|err| Error::Config(ConfigError::TomlEdit(err)))?;
+
+    info!("updated global {key} to {v:?}");
+    config_doc[key] = Item::Value(v.into());
+
+    config_file.rewind()?;
+    config_file.write_all(config_doc.to_string().as_bytes())?;
+
+    Ok(())
+}
+
 const CONFIG: &str = include_str!("../../../.config/config.toml");

--- a/mudpuppy/src/model.rs
+++ b/mudpuppy/src/model.rs
@@ -482,6 +482,7 @@ pub enum Shortcut {
 
     ToggleLineWrap,
     ToggleInputEcho,
+    ToggleMouseMode,
 
     HistoryNext,
     HistoryPrevious,

--- a/mudpuppy/src/tui/annotation.rs
+++ b/mudpuppy/src/tui/annotation.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+use crate::error::Error;
+use crate::idmap::Identifiable;
+use crate::Result;
+use pyo3::types::PyAnyMethods;
+use pyo3::{pyclass, pymethods, Py, Python};
+use ratatui::layout::Rect;
+use ratatui::prelude::Color;
+use ratatui::style::Style;
+use ratatui::Frame;
+use tracing::warn;
+
+#[derive(Debug, Clone)]
+#[pyclass]
+pub struct Annotation {
+    #[pyo3(get)]
+    pub id: u32,
+
+    #[pyo3(get, set)]
+    pub layout_name: String,
+
+    #[pyo3(get, set)]
+    pub enabled: bool,
+
+    #[pyo3(get, set)]
+    pub row: u16,
+
+    #[pyo3(get, set)]
+    pub column: u16,
+
+    #[pyo3(get, set)]
+    pub text: String,
+
+    pub color: Color,
+}
+
+#[pymethods]
+impl Annotation {
+    fn set_colour(&mut self, r: u8, g: u8, b: u8) {
+        self.color = Color::Rgb(r, g, b);
+    }
+
+    fn set_color(&mut self, r: u8, g: u8, b: u8) {
+        self.set_colour(r, g, b);
+    }
+}
+
+impl Identifiable for Py<Annotation> {
+    fn id(&self) -> u32 {
+        Python::with_gil(|py| self.bind(py).extract::<Annotation>().unwrap().id)
+    }
+}
+
+impl Display for Annotation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Annotation({}): {}", self.id, self.text))
+    }
+}
+
+pub fn draw_annotation(
+    annotation: &Py<Annotation>,
+    f: &mut Frame<'_>,
+    sections: &HashMap<String, Rect>,
+) -> Result<()> {
+    Python::with_gil(|py| {
+        let annotation = annotation.borrow_mut(py);
+        if !annotation.enabled {
+            return Ok(());
+        }
+
+        let area = sections
+            .get(&annotation.layout_name)
+            .ok_or_else(|| Error::LayoutMissing(annotation.layout_name.clone()))?;
+
+        let row = annotation.row.saturating_sub(1); // Always one row up
+        let Ok(text_width) = u16::try_from(annotation.text.len()) else {
+            warn!(
+                "annotation {} text too long for u16: {}",
+                annotation.id,
+                annotation.text.len()
+            );
+            return Ok(());
+        };
+
+        let start_col = annotation.column.saturating_sub(text_width / 2);
+        f.buffer_mut().set_string(
+            area.x + start_col,
+            area.y + row,
+            &annotation.text,
+            Style::default().fg(annotation.color),
+        );
+
+        Ok(())
+    })
+}

--- a/mudpuppy/src/tui/button.rs
+++ b/mudpuppy/src/tui/button.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+use pyo3::types::PyAnyMethods;
+use pyo3::{pyclass, Py, PyAny, Python};
+use ratatui::layout::Rect;
+use ratatui::widgets::Widget;
+use ratatui::Frame;
+use tui_framework_experiment::button as tui_button;
+
+use crate::error::Error;
+use crate::idmap::Identifiable;
+use crate::Result;
+
+#[derive(Debug, Clone)]
+#[pyclass]
+pub struct Button {
+    #[pyo3(get)]
+    pub id: u32,
+
+    #[pyo3(get, set)]
+    pub layout_name: String,
+
+    #[pyo3(get, set)]
+    pub label: String,
+
+    #[pyo3(get, set)]
+    pub callback: Py<PyAny>, // Must be async. No return.
+
+    pub(crate) toggle_press: bool,
+}
+
+impl Identifiable for Py<Button> {
+    fn id(&self) -> u32 {
+        Python::with_gil(|py| self.bind(py).extract::<Button>().unwrap().id)
+    }
+}
+
+impl Display for Button {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Button({}): {}", self.id, self.label))
+    }
+}
+
+pub fn draw_button(
+    button: &Py<Button>,
+    f: &mut Frame<'_>,
+    sections: &HashMap<String, Rect>,
+) -> Result<Rect> {
+    Python::with_gil(|py| {
+        let mut py_button = button.borrow_mut(py);
+        let button_area = *sections
+            .get(&py_button.layout_name)
+            .ok_or(Error::LayoutMissing(py_button.layout_name.clone()))?;
+
+        if button_area.is_empty() {
+            return Ok(button_area);
+        }
+
+        // TODO(XXX): styling
+        let mut button =
+            tui_button::Button::new(py_button.label.clone()).with_theme(tui_button::themes::GREEN);
+
+        let toggled = py_button.toggle_press;
+        py_button.toggle_press = false;
+        if toggled {
+            button.toggle_press();
+        }
+
+        button.render(button_area, f.buffer_mut());
+        Ok(button_area)
+    })
+}

--- a/mudpuppy/src/tui/mod.rs
+++ b/mudpuppy/src/tui/mod.rs
@@ -1,4 +1,5 @@
 pub mod buffer;
+pub(crate) mod button;
 pub(crate) mod extrabuffer;
 pub(crate) mod gauge;
 mod input;

--- a/mudpuppy/src/tui/mod.rs
+++ b/mudpuppy/src/tui/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod annotation;
 pub mod buffer;
 pub(crate) mod button;
 pub(crate) mod extrabuffer;

--- a/mudpuppy/src/tui/session.rs
+++ b/mudpuppy/src/tui/session.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn};
 
 use crate::app::{State, Tab, TabAction, TabKind};
 use crate::client::output;
-use crate::config::{edit_mud, GlobalConfig};
+use crate::config::{edit_global, edit_mud, GlobalConfig};
 use crate::error::Error;
 use crate::model::{InputMode, SessionInfo, Shortcut};
 use crate::tui::gauge::draw_gauge;
@@ -98,6 +98,17 @@ impl Tab for Widget {
                     message: format!(
                         "input echo {}",
                         if echo_input { "enabled" } else { "disabled" }
+                    ),
+                });
+            }
+            Shortcut::ToggleMouseMode => {
+                let mouse_enabled = !self.config.lookup(|c| c.mouse_enabled, false);
+                edit_global("mouse_enabled", mouse_enabled)?;
+                client.output.push(output::Item::CommandResult {
+                    error: false,
+                    message: format!(
+                        "mouse support {}",
+                        if mouse_enabled { "enabled" } else { "disabled" }
                     ),
                 });
             }

--- a/mudpuppy/src/tui/session.rs
+++ b/mudpuppy/src/tui/session.rs
@@ -19,6 +19,7 @@ use crate::client::output;
 use crate::config::{edit_global, edit_mud, GlobalConfig};
 use crate::error::Error;
 use crate::model::{InputMode, SessionInfo, Shortcut};
+use crate::tui::annotation::draw_annotation;
 use crate::tui::button::draw_button;
 use crate::tui::gauge::draw_gauge;
 use crate::tui::input::{self, Input};
@@ -266,6 +267,10 @@ impl Tab for Widget {
             // Keep track of where each button drew itself for event handling.
             let area = draw_button(button, frame, &sections)?;
             self.button_areas.insert(*i, area);
+        }
+
+        for (_, annotation) in &client.annotations {
+            draw_annotation(annotation, frame, &sections)?;
         }
 
         Ok(())

--- a/python-examples/custom_layout.py
+++ b/python-examples/custom_layout.py
@@ -12,6 +12,7 @@ from mudpuppy_core import (
     SessionInfo,
     mudpuppy_core,
     Gauge,
+    Button,
 )
 
 from mudpuppy import on_event, unload_handlers
@@ -21,6 +22,7 @@ GAUGE_SECTION = "gauges"
 HP_GAUGE_SECTION = "hp_gauge"
 CP_GAUGE_SECTION = "cp_gauge"
 STATUS_SECTION = "status"
+NAV_AREA_SECTION = "nav_area"
 CUSTOM_LAYOUT_READY = "custom_layout_ready"
 
 
@@ -33,6 +35,7 @@ class TestCustomLayout:
     status_buffer_id: Optional[int] = None
     status_on_left: bool = False
     gauges: Optional[Dict[str, Gauge]] = None
+    nav_buttons: Optional[Dict[int, Button]] = None
 
     # TODO(XXX): expose status_on_left setting?
     def __init__(self, sesh_id: int):
@@ -73,8 +76,11 @@ class TestCustomLayout:
                 buffer_config=self.status_buffer,
                 old_section_first=not self.status_on_left,
             )
-        logging.debug(f"status buffer id: {status_buffer_id}")
-        self.status_buffer_id = status_buffer_id
+            logging.debug(f"status buffer id: {status_buffer_id}")
+            self.status_buffer_id = status_buffer_id
+
+        # Set up a nav button area below the STATUS_SECTION.
+        await self.nav_layout_init(layout_manager)
 
         channel_buffer_id = next(
             (
@@ -102,72 +108,260 @@ class TestCustomLayout:
         self.channel_buffer_id = channel_buffer_id
 
         if self.gauges is None:
-            logging.debug(f"creating gauge section for {self.session_id}")
-            # Create a veritical split for the set of gauges
-            await layout_manager.split_section(
-                self.session_id,
-                section_name="output_area",
-                constraint=Constraint.with_min(1),
-                new_section_name=GAUGE_SECTION,
-                new_constraint=Constraint.with_max(3),
-                direction=Direction.Vertical,
-                old_section_first=True,
-            )
-            # Extend the gauge section with a horizontal section for the HP gauge
-            await layout_manager.extend_section(
-                self.session_id,
-                section_name=GAUGE_SECTION,
-                new_section_name=HP_GAUGE_SECTION,
-                constraint=Constraint.with_percentage(50),
-                direction=Direction.Horizontal,
-            )
-            # Extend the gauge section with a horizontal section for the CP gauge
-            await layout_manager.extend_section(
-                self.session_id,
-                section_name=GAUGE_SECTION,
-                new_section_name=CP_GAUGE_SECTION,
-                constraint=Constraint.with_percentage(50),
-                direction=Direction.Horizontal,
-            )
-
-            # Create the HP gauge, assigned to the HP_GAUGE_SECTION
-            logging.debug(f"creating health gauge for {self.session_id}")
-            health_gauge = await mudpuppy_core.new_gauge(
-                self.session_id,
-                layout_name=HP_GAUGE_SECTION,
-                title="HP",
-                rgb=(0, 255, 0),
-            )
-            logging.debug(f"health gauge id: {health_gauge.id}")
-
-            # Create the CP gauge, assigned to the CP_GAUGE_SECTION
-            logging.debug(f"creating cp gauge for {self.session_id}")
-            cp_gauge = await mudpuppy_core.new_gauge(
-                self.session_id,
-                layout_name=CP_GAUGE_SECTION,
-                title="CP",
-                rgb=(0, 0, 255),
-            )
-            logging.debug(f"cp gauge id: {cp_gauge.id}")
-
-            # Store both gauges keyed by their layout name.
-            # Consumers can poke at the Gauge instances in this dict to update as needed.
-            self.gauges = {HP_GAUGE_SECTION: health_gauge, CP_GAUGE_SECTION: cp_gauge}
+            await self.gauge_layout_init(layout_manager)
 
         await mudpuppy_core.emit_event(CUSTOM_LAYOUT_READY, None, self.session_id)
 
-    def toggle_status_area(self):
-        constraint = manager.get_constraint(self.session_id, STATUS_SECTION)
+    # TODO(XXX): deduplicate/tidy this code a bit :)
+    # TODO(XXX): fix for /reload ?
+    async def nav_layout_init(self, layout_manager: LayoutManager):
+        # Create a section under the status buffer for the navigation buttons
+        await layout_manager.split_section(
+            self.session_id,
+            section_name=STATUS_SECTION,
+            constraint=Constraint.with_percentage(80),
+            new_section_name=NAV_AREA_SECTION,
+            new_constraint=Constraint.with_min(12),
+            direction=Direction.Vertical,
+            old_section_first=True,
+        )
+
+        # Extend the nav area into three rows
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION,
+            new_section_name="nav_area_top",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Vertical,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION,
+            new_section_name="nav_area_middle",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Vertical,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION,
+            new_section_name="nav_area_bottom",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Vertical,
+        )
+
+        # Extend each nav area row into three sub-sections
+
+        # Top row: NW, N, NE
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_top",
+            new_section_name=NAV_AREA_SECTION + "_top_left",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_top",
+            new_section_name=NAV_AREA_SECTION + "_top_middle",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_top",
+            new_section_name=NAV_AREA_SECTION + "_top_right",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+
+        # Middle row: W, Look, E
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_middle",
+            new_section_name=NAV_AREA_SECTION + "_middle_left",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_middle",
+            new_section_name=NAV_AREA_SECTION + "_middle_middle",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_middle",
+            new_section_name=NAV_AREA_SECTION + "_middle_right",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+
+        # Bottom row: SW, S, SE
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_bottom",
+            new_section_name=NAV_AREA_SECTION + "_bottom_left",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_bottom",
+            new_section_name=NAV_AREA_SECTION + "_bottom_middle",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=NAV_AREA_SECTION + "_bottom",
+            new_section_name=NAV_AREA_SECTION + "_bottom_right",
+            constraint=Constraint.with_percentage(33),
+            direction=Direction.Horizontal,
+        )
+
+        # Create the nav buttons!
+        logging.debug("creating nav buttons for {self.session_id}")
+
+        # Top row: NW, N, NE
+        nav_north_west_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_top_left",
+            label="NW",
+        )
+        nav_north_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_top_middle",
+            label="N",
+        )
+        nav_north_east_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_top_right",
+            label="NE",
+        )
+
+        # Middle row: W, Look, E
+        nav_west_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_middle_left",
+            label="W",
+        )
+        nav_look_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_middle_middle",
+            label="Look",
+        )
+        nav_east_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_middle_right",
+            label="E",
+        )
+
+        # Bottom row: SW, S, SE
+        nav_north_south_west_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_bottom_left",
+            label="SW",
+        )
+        nav_south_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_bottom_middle",
+            label="S",
+        )
+        nav_south_east_btn = await mudpuppy_core.new_button(
+            self.session_id,
+            self.nav_button_click,
+            layout_name=NAV_AREA_SECTION + "_bottom_right",
+            label="SE",
+        )
+
+        # Store the created nav buttons in a dict for easy access by button ID.
+        self.nav_buttons = {
+            nav_north_west_btn.id: nav_north_west_btn,
+            nav_north_btn.id: nav_north_btn,
+            nav_north_east_btn.id: nav_north_east_btn,
+            nav_west_btn.id: nav_west_btn,
+            nav_look_btn.id: nav_look_btn,
+            nav_east_btn.id: nav_east_btn,
+            nav_north_south_west_btn.id: nav_north_south_west_btn,
+            nav_south_btn.id: nav_south_btn,
+            nav_south_east_btn.id: nav_south_east_btn,
+        }
+
+    async def gauge_layout_init(self, layout_manager: LayoutManager):
+        logging.debug(f"creating gauge section for {self.session_id}")
+        # Create a veritical split for the set of gauges
+        await layout_manager.split_section(
+            self.session_id,
+            section_name="output_area",
+            constraint=Constraint.with_min(1),
+            new_section_name=GAUGE_SECTION,
+            new_constraint=Constraint.with_max(3),
+            direction=Direction.Vertical,
+            old_section_first=True,
+        )
+        # Extend the gauge section with a horizontal section for the HP gauge
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=GAUGE_SECTION,
+            new_section_name=HP_GAUGE_SECTION,
+            constraint=Constraint.with_percentage(50),
+            direction=Direction.Horizontal,
+        )
+        # Extend the gauge section with a horizontal section for the CP gauge
+        await layout_manager.extend_section(
+            self.session_id,
+            section_name=GAUGE_SECTION,
+            new_section_name=CP_GAUGE_SECTION,
+            constraint=Constraint.with_percentage(50),
+            direction=Direction.Horizontal,
+        )
+        # Create the HP gauge, assigned to the HP_GAUGE_SECTION
+        logging.debug(f"creating health gauge for {self.session_id}")
+        health_gauge = await mudpuppy_core.new_gauge(
+            self.session_id,
+            layout_name=HP_GAUGE_SECTION,
+            title="HP",
+            rgb=(0, 255, 0),
+        )
+        logging.debug(f"health gauge id: {health_gauge.id}")
+
+        # Create the CP gauge, assigned to the CP_GAUGE_SECTION
+        logging.debug(f"creating cp gauge for {self.session_id}")
+        cp_gauge = await mudpuppy_core.new_gauge(
+            self.session_id,
+            layout_name=CP_GAUGE_SECTION,
+            title="CP",
+            rgb=(0, 0, 255),
+        )
+        logging.debug(f"cp gauge id: {cp_gauge.id}")
+
+        # Store both gauges keyed by their layout name.
+        # Consumers can poke at the Gauge instances in this dict to update as needed.
+        self.gauges = {HP_GAUGE_SECTION: health_gauge, CP_GAUGE_SECTION: cp_gauge}
+
+    def toggle_status_and_nav_area(self):
+        section = STATUS_SECTION + "_" + NAV_AREA_SECTION
+        constraint = manager.get_constraint(self.session_id, section)
         if constraint.max == 0:
             manager.show_section(
-                self.session_id, STATUS_SECTION, Constraint.with_percentage(25)
+                self.session_id, section, Constraint.with_percentage(25)
             )
         else:
-            manager.hide_section(self.session_id, STATUS_SECTION)
+            manager.hide_section(self.session_id, section)
 
-    def resize_status_area(self, amount: int = 5):
+    def resize_status_and_nav_area(self, amount: int = 5):
+        section = STATUS_SECTION + "_" + NAV_AREA_SECTION
         logging.debug(f"resizing status area by {amount}")
-        constraint = manager.get_constraint(self.session_id, STATUS_SECTION)
+        constraint = manager.get_constraint(self.session_id, section)
         logging.debug(f"current: {constraint}")
         if constraint.percentage is None or constraint.percentage == 0:
             return
@@ -199,6 +393,11 @@ class TestCustomLayout:
         else:
             manager.hide_section(self.session_id, GAUGE_SECTION)
 
+    async def nav_button_click(self, session_id: int, button_id: int):
+        assert self.nav_buttons is not None
+        clicked_btn = self.nav_buttons[button_id]
+        await mudpuppy_core.send_line(session_id, clicked_btn.label.lower())
+
 
 async def layout_init(session: SessionInfo, layout_manager: LayoutManager):
     logging.debug("processing custom layout init")
@@ -229,7 +428,7 @@ async def on_key(event: Event):
         layout.toggle_channel_area()
         return
     elif no_modifiers and code == "f5":
-        layout.toggle_status_area()
+        layout.toggle_status_and_nav_area()
         return
     elif no_modifiers and code == "f6":
         layout.toggle_gauge_area()
@@ -237,9 +436,9 @@ async def on_key(event: Event):
 
     if modifiers == ["alt"]:
         if code == "h":
-            layout.resize_status_area(5)
+            layout.resize_status_and_nav_area(5)
         elif code == "l":
-            layout.resize_status_area(-5)
+            layout.resize_status_and_nav_area(-5)
         elif code == "j":
             layout.resize_channel_area(5)
         elif code == "k":

--- a/python-examples/custom_layout.py
+++ b/python-examples/custom_layout.py
@@ -36,6 +36,7 @@ class TestCustomLayout:
     status_on_left: bool = False
     gauges: Optional[Dict[str, Gauge]] = None
     nav_buttons: Optional[Dict[int, Button]] = None
+    layout_manager: Optional[LayoutManager] = None
 
     # TODO(XXX): expose status_on_left setting?
     def __init__(self, sesh_id: int):
@@ -57,6 +58,7 @@ class TestCustomLayout:
             self.status_buffer.border_left = True
 
     async def layout_init(self, layout_manager: LayoutManager):
+        self.layout_manager = layout_manager
         existing_buffers = await mudpuppy_core.buffers(self.session_id)
 
         status_buffer_id = next(

--- a/python-stubs/mudpuppy_core.pyi
+++ b/python-stubs/mudpuppy_core.pyi
@@ -46,6 +46,8 @@ __all__ = [
     "BufferDirection",
     "ExtraBuffer",
     "Gauge",
+    "Button",
+    "ButtonCallable",
 ]
 
 from typing import Optional, Any, Callable, Awaitable, Tuple
@@ -1541,6 +1543,42 @@ class Gauge:
         """
         ...
 
+type ButtonCallable = Callable[[int, int], Awaitable[None]]
+"""
+An async function that is called when a button is clicked.
+
+Typically assigned to a `Button`'s `callback` property.
+
+The callable is called with:
+
+* the `int` session ID of the session that owns the button that was clicked.
+* the `int` button ID of the button that was clicked.
+"""
+
+class Button:
+    """
+    A button widget that can be created with `MudpuppyCore.new_button()`.
+    """
+
+    id: int
+    """
+    The read-only `int` ID assigned to the button.
+    """
+
+    layout_name: str
+    """
+    The layout name where the `Button` should be drawn.
+
+    Can be both read and set.
+    """
+
+    label: str
+    """
+    The label for the button.
+    """
+
+    callback: ButtonCallable
+
 class Input:
     """
     The input area of the client window.
@@ -2212,6 +2250,23 @@ class MudpuppyCore:
 
         Returns the created `Gauge` instance. You can read/write values of this instance
         to customize the gauge.
+        """
+        ...
+
+    async def new_button(
+        self,
+        session_id: int,
+        callback: ButtonCallable,
+        *,
+        label: Optional[str] = None,
+        layout_name: Optional[str] = None,
+    ) -> Button:
+        """
+        Creates a new `Button` based on the provided arguments, for the given `session_id`.
+        The `ButtonCallable` will be invoked when the button is clicked.
+
+        Returns the created `Button` instance. You can read/write values of this instance
+        to customize the button.
         """
         ...
 

--- a/user-guide/src/config/mouse.md
+++ b/user-guide/src/config/mouse.md
@@ -11,9 +11,6 @@ mouse_enabled = true
 Make sure this configuration is outside of any [MUD] or [Keybinding] stanzas in
 your config TOML.
 
-Note that unlike other settings, you **must** restart Mudpuppy for a change to
-`mouse_enabled` to take effect.
-
 <div class="warning">
 <strong>Important:</strong> mouse mode often interferes with selecting text to
 copy/paste. Support for mouse mode varies by terminal.
@@ -33,6 +30,3 @@ are used to scroll the output history scrollback buffer using the global setting
 mouse_enabled = true
 mouse_scroll = true
 ```
-
-You can change `mouse_scroll` without restarting Mudpuppy, but remeber that
-changes to `mouse_enabled` require a restart.


### PR DESCRIPTION
* Properly disable mouse capture on exit. This prevents weirdness in the terminal after exiting when `mouse_enabled` was true.
* Allow changing mouse mode without a restart. This removes the previous limitation that required a restart of the client for the change to take effect. A new `ToggleMouseMode` shortcut is added, and bound to F8 by default, to toggle mouse mode from within the client. The user manual is updated to remove the mentions of needing a restart.
* Add button widgets, scriptable with Python. These are missing styling, but function in the most basic prototype sense. You can create buttons from Python, and have an async callback invoked when they're clicked in mouse mode. The `custom_layout.py` example is updated to add navigation buttons for moving around in-game. For now we take a dep on `tui-framework-experiment` to borrow its button widgets. Likely it makes more sense to implement something similar from scratch. Taking this dep also requires an MSRV bump to 1.80.
* Start rough prototype of text annotations. Not super happy with this yet, so there's no stub/API documentation written yet. Allows adding text annotations to different layout sections. Used by the spellcheck example to provide misspelled word suggestions.