### PR TITLE
minor iterations on spellcheck/annotations

### DIFF
--- a/mudpuppy/src/python.rs
+++ b/mudpuppy/src/python.rs
@@ -1144,7 +1144,7 @@ impl PyApp {
         })
     }
 
-    #[pyo3(signature = (session_id, row, column, text, layout_name, *, enabled = true, rgb = None))]
+    #[pyo3(signature = (session_id, row, column, text, layout_name, *, rgb = None))]
     #[allow(clippy::too_many_arguments)]
     fn new_annotation<'py>(
         &self,
@@ -1154,7 +1154,6 @@ impl PyApp {
         column: u16,
         text: String,
         layout_name: String,
-        enabled: bool,
         rgb: Option<(u8, u8, u8)>,
     ) -> PyResult<Bound<'py, PyAny>> {
         with_state!(self, py, |mut state| {
@@ -1170,7 +1169,6 @@ impl PyApp {
                                 id,
                                 row,
                                 column,
-                                enabled,
                                 text,
                                 layout_name,
                                 color: rgb.map(|(r, g, b)| Color::Rgb(r, g, b)).unwrap_or_default(),

--- a/mudpuppy/src/tui/annotation.rs
+++ b/mudpuppy/src/tui/annotation.rs
@@ -22,9 +22,6 @@ pub struct Annotation {
     pub layout_name: String,
 
     #[pyo3(get, set)]
-    pub enabled: bool,
-
-    #[pyo3(get, set)]
     pub row: u16,
 
     #[pyo3(get, set)]
@@ -66,9 +63,6 @@ pub fn draw_annotation(
 ) -> Result<()> {
     Python::with_gil(|py| {
         let annotation = annotation.borrow_mut(py);
-        if !annotation.enabled {
-            return Ok(());
-        }
 
         let area = sections
             .get(&annotation.layout_name)


### PR DESCRIPTION
* don't bother with enabled state. Not very useful, better to redraw no content.
* clear annotation on input sent events.
* tidy some spellcheck example code.