### PR TITLE
buffer: workaround ratatui complex emoji buffer corruption

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739020877,
-        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "lastModified": 1740367490,
+        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1738981474,
-        "narHash": "sha256-YIELTXxfATG0g1wXjyaOWA4qrlubds3MG4FvMPCxSGg=",
+        "lastModified": 1740450604,
+        "narHash": "sha256-T/lqASXzCzp5lJISCUw+qwfRmImVUnhKgAhn8ymRClI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5c571e5ff246d8fc5f76ba6e38dc8edb6e4002fe",
+        "rev": "5961ca311c85c31fc5f51925b4356899eed36221",
         "type": "github"
       },
       "original": {

--- a/mudpuppy/src/idmap.rs
+++ b/mudpuppy/src/idmap.rs
@@ -98,7 +98,6 @@ impl<Value> Default for IdMap<Value>
 where
     Value: Identifiable + Debug + Display,
 {
-    #[must_use]
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
Pretty gross hack, but it's sufficient to prevent buffer corruption when working through the entire list of emoji DuneMUD recognizes.

Some more complex emoji will lose indicators like skin tone, but until there's an upstream fix this is better than corrupting the TUI and leaving half-drawn stuff all over the place.

Resolves https://github.com/mudpuppy-rs/mudpuppy/issues/80 (_TODO: update that issue with some breadcrumbs to the upstream work to be done_).