### PR TITLE
app: take the active session ID on tab close

### DIFF
--- a/mudpuppy/src/app.rs
+++ b/mudpuppy/src/app.rs
@@ -392,7 +392,7 @@ impl App {
             }
             TabAction::Close => {
                 self.tabs.remove(state.selected_tab);
-                if let Some(session_id) = state.active_session_id {
+                if let Some(session_id) = state.active_session_id.take() {
                     state.clients.remove(session_id);
                 }
                 state.selected_tab = state.selected_tab.saturating_sub(1);


### PR DESCRIPTION
There's no active session ID after this! 

Merged https://github.com/mudpuppy-rs/mudpuppy/pull/107 a touch too quickly.